### PR TITLE
Fix Android Subscription and notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ window.FirebasePlugin.grantPermission();
 
 Subscribe to a topic:
 ```
-window.FirebasePlugin.subscribe("/topics/example");
+window.FirebasePlugin.subscribe("/example");
 ```
 
 ### unsubscribe
 
 Unsubscribe from a topic:
 ```
-window.FirebasePlugin.unsubscribe("/topics/example");
+window.FirebasePlugin.unsubscribe("/example");
 ```
 
 ### logEvent

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,6 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		</config-file>
 		<config-file parent="/*" target="res/values/strings.xml">
 		    <string name="google_app_id">@string/google_app_id</string>
-				<string name="google_api_key">@string/google_api_key</string>
 		</config-file>
 		<config-file parent="/*" target="AndroidManifest.xml">
 			<service android:name=".FirebasePluginMessagingService">

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,6 +22,8 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		</config-file>
 		<config-file parent="/*" target="res/values/strings.xml">
 		    <string name="google_app_id">@string/google_app_id</string>
+		</config-file>
+		<config-file parent="/*" target="res/values/strings.xml">
 				<string name="google_api_key">@string/google_api_key</string>
 		</config-file>
 		<config-file parent="/*" target="AndroidManifest.xml">

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,6 +22,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		</config-file>
 		<config-file parent="/*" target="res/values/strings.xml">
 		    <string name="google_app_id">@string/google_app_id</string>
+				<string name="google_api_key">@string/google_api_key</string>
 		</config-file>
 		<config-file parent="/*" target="AndroidManifest.xml">
 			<service android:name=".FirebasePluginMessagingService">

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-firebase" version="0.1.7" xmlns="http://apache.org/cordova/ns/plugins/1.0" 
+<plugin id="cordova-plugin-firebase" version="0.1.7" xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android">
 	<name>Google Firebase Plugin</name>
 
@@ -16,7 +16,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 	<platform name="android">
 		<config-file parent="/*" target="res/xml/config.xml">
 			<feature name="FirebasePlugin">
-				<param name="android-package" value="org.apache.cordova.firebase.FirebasePlugin" />
+				<param name="android-package" value="org.apache.cordova.firebase.FirebasePlugin.FirebasePlugin" />
 				<param name="onload" value="true" />
 			</feature>
 		</config-file>
@@ -39,7 +39,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		<source-file src="src/android/FirebasePlugin.java" target-dir="src/org/apache/cordova/firebase/FirebasePlugin" />
 		<source-file src="src/android/FirebasePluginInstanceIDService.java" target-dir="src/org/apache/cordova/firebase/FirebasePlugin" />
 		<source-file src="src/android/FirebasePluginMessagingService.java" target-dir="src/org/apache/cordova/firebase/FirebasePlugin" />
- 
+
 		<framework src="src/android/build.gradle" custom="true" type="gradleReference" />
 		<framework src="com.google.firebase:firebase-core:9.0.2" />
 		<framework src="com.google.firebase:firebase-messaging:9.0.2" />

--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -19,7 +19,7 @@ try {
 	var contents = fs.readFileSync("GoogleService-Info.plist").toString();
     fs.writeFileSync("platforms/ios/" + name + "/Resources/GoogleService-Info.plist", contents)
 } catch(err) {
-  process.stdout.write(err);
+//  process.stdout.write(err);
 }
 
 try {
@@ -38,7 +38,17 @@ try {
     // replace the default value
     strings = strings.replace(new RegExp('<string name="google_app_id">([^<]+?)</string>', "i"), '<string name="google_app_id">' + json.client[0].client_info.mobilesdk_app_id + '</string>')
 
+
+    // strip non-default value
+    strings = strings.replace(new RegExp('<string name="google_api_key">([^@<]+?)</string>', "i"), '')
+
+    // strip empty lines
+    strings = strings.replace(new RegExp('(\r\n|\n|\r)[ \t]*(\r\n|\n|\r)', "gm"), '$1')
+
+    // replace the default value
+    strings = strings.replace(new RegExp('<string name="google_api_key">([^<]+?)</string>', "i"), '<string name="google_app_id">' + json.client[0].api_key.current_key + '</string>')
+
     fs.writeFileSync("platforms/android/res/values/strings.xml", strings);
 } catch(err) {
-  process.stdout.write(err);
+//  process.stdout.write(err);
 }

--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -18,7 +18,9 @@ var name = getValue(config, "name")
 try {
 	var contents = fs.readFileSync("GoogleService-Info.plist").toString();
     fs.writeFileSync("platforms/ios/" + name + "/Resources/GoogleService-Info.plist", contents)
-} catch(err) {}
+} catch(err) {
+  process.stdout.write(err);
+}
 
 try {
 	var contents = fs.readFileSync("google-services.json").toString();
@@ -37,4 +39,6 @@ try {
     strings = strings.replace(new RegExp('<string name="google_app_id">([^<]+?)</string>', "i"), '<string name="google_app_id">' + json.client[0].client_info.mobilesdk_app_id + '</string>')
 
     fs.writeFileSync("platforms/android/res/values/strings.xml", strings);
-} catch(err) {}
+} catch(err) {
+  process.stdout.write(err);
+}

--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -42,7 +42,7 @@ try {
     strings = strings.replace(new RegExp('<string name="google_app_id">([^<]+?)</string>', "i"), '<string name="google_app_id">' + json.client[0].client_info.mobilesdk_app_id + '</string>')
 
     // replace the default value
-    strings = strings.replace(new RegExp('<string name="google_api_key">([^<]+?)</string>', "i"), '<string name="google_app_id">' + json.client[0].api_key[0].current_key + '</string>')
+    strings = strings.replace(new RegExp('<string name="google_api_key">([^<]+?)</string>', "i"), '<string name="google_api_key">' + json.client[0].api_key[0].current_key + '</string>')
 
     fs.writeFileSync("platforms/android/res/values/strings.xml", strings);
 } catch(err) {

--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -19,7 +19,7 @@ try {
 	var contents = fs.readFileSync("GoogleService-Info.plist").toString();
     fs.writeFileSync("platforms/ios/" + name + "/Resources/GoogleService-Info.plist", contents)
 } catch(err) {
-//  process.stdout.write(err);
+  process.stdout.write(err);
 }
 
 try {
@@ -30,7 +30,10 @@ try {
     var strings = fs.readFileSync("platforms/android/res/values/strings.xml").toString();
 
     // strip non-default value
-    strings = strings.replace(new RegExp('<string name="google_app_id">([^@<]+?)</string>', "i"), '')
+    strings = strings.replace(new RegExp('<string name="google_app_id">([^\@<]+?)</string>˜', "i"), '')
+
+    // strip non-default value
+    strings = strings.replace(new RegExp('<string name="google_api_key">([^\@<]+?)</string>˜', "i"), '')
 
     // strip empty lines
     strings = strings.replace(new RegExp('(\r\n|\n|\r)[ \t]*(\r\n|\n|\r)', "gm"), '$1')
@@ -38,17 +41,10 @@ try {
     // replace the default value
     strings = strings.replace(new RegExp('<string name="google_app_id">([^<]+?)</string>', "i"), '<string name="google_app_id">' + json.client[0].client_info.mobilesdk_app_id + '</string>')
 
-
-    // strip non-default value
-    strings = strings.replace(new RegExp('<string name="google_api_key">([^@<]+?)</string>', "i"), '')
-
-    // strip empty lines
-    strings = strings.replace(new RegExp('(\r\n|\n|\r)[ \t]*(\r\n|\n|\r)', "gm"), '$1')
-
     // replace the default value
-    strings = strings.replace(new RegExp('<string name="google_api_key">([^<]+?)</string>', "i"), '<string name="google_app_id">' + json.client[0].api_key.current_key + '</string>')
+    strings = strings.replace(new RegExp('<string name="google_api_key">([^<]+?)</string>', "i"), '<string name="google_app_id">' + json.client[0].api_key[0].current_key + '</string>')
 
     fs.writeFileSync("platforms/android/res/values/strings.xml", strings);
 } catch(err) {
-//  process.stdout.write(err);
+  process.stdout.write(err);
 }

--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -38,6 +38,16 @@ try {
     // replace the default value
     strings = strings.replace(new RegExp('<string name="google_app_id">([^<]+?)</string>', "i"), '<string name="google_app_id">' + json.client[0].client_info.mobilesdk_app_id + '</string>')
 
+
+    // strip non-default value
+    strings = strings.replace(new RegExp('<string name="google_api_key">([^@<]+?)</string>', "i"), '')
+
+    // strip empty lines
+    strings = strings.replace(new RegExp('(\r\n|\n|\r)[ \t]*(\r\n|\n|\r)', "gm"), '$1')
+
+    // replace the default value
+    strings = strings.replace(new RegExp('<string name="google_api_key">([^<]+?)</string>', "i"), '<string name="google_app_id">' + json.client[0].api_key.current_key + '</string>')
+
     fs.writeFileSync("platforms/android/res/values/strings.xml", strings);
 } catch(err) {
   process.stdout.write(err);

--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -38,16 +38,6 @@ try {
     // replace the default value
     strings = strings.replace(new RegExp('<string name="google_app_id">([^<]+?)</string>', "i"), '<string name="google_app_id">' + json.client[0].client_info.mobilesdk_app_id + '</string>')
 
-
-    // strip non-default value
-    strings = strings.replace(new RegExp('<string name="google_api_key">([^@<]+?)</string>', "i"), '')
-
-    // strip empty lines
-    strings = strings.replace(new RegExp('(\r\n|\n|\r)[ \t]*(\r\n|\n|\r)', "gm"), '$1')
-
-    // replace the default value
-    strings = strings.replace(new RegExp('<string name="google_api_key">([^<]+?)</string>', "i"), '<string name="google_app_id">' + json.client[0].api_key.current_key + '</string>')
-
     fs.writeFileSync("platforms/android/res/values/strings.xml", strings);
 } catch(err) {
   process.stdout.write(err);

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -1,4 +1,4 @@
-package org.apache.cordova.firebase;
+package org.apache.cordova.firebase.FirebasePlugin;
 
 import android.content.Context;
 import android.util.Log;
@@ -12,6 +12,7 @@ import org.json.JSONException;
 
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.analytics.FirebaseAnalytics;
+import com.google.firebase.messaging.FirebaseMessaging;
 
 
 public class FirebasePlugin extends CordovaPlugin {
@@ -26,6 +27,8 @@ public class FirebasePlugin extends CordovaPlugin {
             public void run() {
                 Log.d(TAG, "Starting Firebase plugin");
                 mFirebaseAnalytics = FirebaseAnalytics.getInstance(context);
+                FirebaseMessaging.getInstance().subscribeToTopic("android");
+                FirebaseMessaging.getInstance().subscribeToTopic("all");
             }
         });
     }
@@ -54,12 +57,12 @@ public class FirebasePlugin extends CordovaPlugin {
     }
 
     private void subscribe(CallbackContext callbackContext, String topic) {
-        FirebaseInstanceId.getInstance().subscribeToTopic(topic);
+        FirebaseMessaging.getInstance().subscribeToTopic(topic);
         callbackContext.success();
     }
 
     private void unsubscribe(CallbackContext callbackContext, String topic) {
-        FirebaseInstanceId.getInstance().unsubscribeFromTopic(topic);
+        FirebaseMessaging.getInstance().unsubscribeFromTopic(topic);
         callbackContext.success();
     }
 

--- a/src/android/FirebasePluginInstanceIDService.java
+++ b/src/android/FirebasePluginInstanceIDService.java
@@ -1,4 +1,4 @@
-package org.apache.cordova.firebase;
+package org.apache.cordova.firebase.FirebasePlugin;
 
 import android.util.Log;
 
@@ -8,7 +8,7 @@ import com.google.firebase.iid.FirebaseInstanceIdService;
 
 public class FirebasePluginInstanceIDService extends FirebaseInstanceIdService {
 
-    private static final String TAG = "FirebasePluginInstanceIDService";
+    private static final String TAG = "FirebasePlugin";
 
     /**
      * Called if InstanceID token is updated. This may occur if the security of

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -1,14 +1,24 @@
-package org.apache.cordova.firebase;
+package org.apache.cordova.firebase.FirebasePlugin;
 
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.media.RingtoneManager;
+import android.net.Uri;
+import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
+import java.util.Map;
+
 
 public class FirebasePluginMessagingService extends FirebaseMessagingService {
 
-    private static final String TAG = "FirebasePluginMessagingService";
+    private static final String TAG = "FirebasePlugin";
 
     /**
      * Called when message is received.
@@ -21,7 +31,57 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
         // If the application is in the foreground handle both data and notification messages here.
         // Also if you intend on generating your own notifications as a result of a received FCM
         // message, here is where that should be initiated. See sendNotification method below.
+        String title = null;
+        String text = null;
+        int id = 0;
+        if (remoteMessage.getNotification() != null) {
+            title = remoteMessage.getNotification().getTitle();
+            text = remoteMessage.getNotification().getBody();
+        } else {
+            title = remoteMessage.getData().get("title");
+            text = remoteMessage.getData().get("text");
+            try {
+                id = Integer.valueOf(remoteMessage.getData().get("id"));
+            } catch (Exception e) {
+                // ignore
+            }
+        }
         Log.d(TAG, "From: " + remoteMessage.getFrom());
-        Log.d(TAG, "Notification Message Body: " + remoteMessage.getNotification().getBody());
+        Log.d(TAG, "Notification Message Title: " + title);
+        Log.d(TAG, "Notification Message Body/Text: " + text);
+
+        // TODO: Add option to developer to configure if show notification when app on foreground
+        if (text != null && title != null) {
+            sendNotification(id, title, text, remoteMessage.getData());
+        }
     }
+
+    private void sendNotification(int id, String title, String messageBody, Map<String, String> data) {
+        PackageManager pm = getPackageManager();
+        Intent intent = pm.getLaunchIntentForPackage(getApplicationContext().getPackageName());
+
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        for (String key : data.keySet()) {
+            intent.putExtra(key, data.get(key));
+        }
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0 /* Request code */, intent,
+                PendingIntent.FLAG_ONE_SHOT);
+
+        Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
+        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this)
+                .setSmallIcon(getApplicationInfo().icon)
+                .setContentTitle(title)
+                .setContentText(messageBody)
+                .setStyle(new NotificationCompat.BigTextStyle().bigText(messageBody))
+                .setAutoCancel(true)
+                .setSound(defaultSoundUri)
+                .setContentIntent(pendingIntent);
+
+        NotificationManager notificationManager =
+                (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+
+        notificationManager.notify(id, notificationBuilder.build());
+    }
+
+
 }

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -8,8 +8,8 @@ exports.grantPermission = function(success, error) {
     exec(success, error, "FirebasePlugin", "grantPermission", []);
 };
 
-exports.unsubscribe = function(topic, success, error) {
-    exec(success, error, "FirebasePlugin", "unsubscribe", [topic]);
+exports.subscribe = function(topic, success, error) {
+    exec(success, error, "FirebasePlugin", "subscribe", [topic]);
 };
 
 exports.unsubscribe = function(topic, success, error) {


### PR DESCRIPTION
This PR fixes Android subscription and adds support to notifications when app in foreground or data notifications.
I think many app developers will want to keep showing the notifications even with the app on foreground, on Android, to do so you need to do it by yourself. that is why I implemented the sendNotification method.
Also, the default firebase notification is garbage (only one line notification text) and the only way to force a developer defined notification is using the "data" notification so I implemented it too.

I know many others will want the default firebase settings (if the app is in foreground, don`t show a notification), but it implement it I would need to add this option to the cordova plugin and I am not ready to do so.

I am not an iOS developer, so I can`t help much with the iOS version, you can take a look here to add the same support to the iOS version.
https://github.com/fechanique/cordova-plugin-fcm/blob/master/src/ios/AppDelegate%2BFCMPlugin.m

PS: In the subscribe sample from firebase, in the Android sample it passes just the topic name, not the "/topics/$NAME" as done in the iOS sample, so I think it would be easier to append the topic name in the iOS implementation.

PS1: There is an issue where the google_app_id and google_api_key are always inserted in the strings.xml, maybe stop adding them in the plugin.xml and just insert at the end of the strings.xml file if it does not exist solves this problem.