### PR TITLE
OnNotificationOpen callback

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -41,6 +41,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		</config-file>
 		<source-file src="src/android/google-services.json" target-dir="." />
 		<source-file src="src/android/FirebasePlugin.java" target-dir="src/org/apache/cordova/firebase" />
+		<source-file src="src/android/OnNotificationOpenReceiver.java" target-dir="src/org/apache/cordova/firebase" />
 		<source-file src="src/android/FirebasePluginInstanceIDService.java" target-dir="src/org/apache/cordova/firebase" />
 		<source-file src="src/android/FirebasePluginMessagingService.java" target-dir="src/org/apache/cordova/firebase" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -16,17 +16,17 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 	<platform name="android">
 		<config-file parent="/*" target="res/xml/config.xml">
 			<feature name="FirebasePlugin">
-				<param name="android-package" value="org.apache.cordova.firebase.FirebasePlugin.FirebasePlugin" />
+				<param name="android-package" value="org.apache.cordova.firebase.FirebasePlugin" />
 				<param name="onload" value="true" />
 			</feature>
 		</config-file>
-		<config-file parent="/*" target="res/values/strings.xml">
-		    <string name="google_app_id">@string/google_app_id</string>
+		<config-file parent="/resources" target="res/values/strings.xml">
+			<string name="google_app_id">@string/google_app_id</string>
 		</config-file>
-		<config-file parent="/*" target="res/values/strings.xml">
+		<config-file parent="/resources" target="res/values/strings.xml">
 			<string name="google_api_key">@string/google_api_key</string>
 		</config-file>
-		<config-file parent="/*" target="AndroidManifest.xml">
+		<config-file target="AndroidManifest.xml" parent="/manifest/application">
 			<service android:name=".FirebasePluginMessagingService">
 				<intent-filter>
 					<action android:name="com.google.firebase.MESSAGING_EVENT"/>
@@ -39,9 +39,9 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 			</service>
 		</config-file>
 		<source-file src="src/android/google-services.json" target-dir="." />
-		<source-file src="src/android/FirebasePlugin.java" target-dir="src/org/apache/cordova/firebase/FirebasePlugin" />
-		<source-file src="src/android/FirebasePluginInstanceIDService.java" target-dir="src/org/apache/cordova/firebase/FirebasePlugin" />
-		<source-file src="src/android/FirebasePluginMessagingService.java" target-dir="src/org/apache/cordova/firebase/FirebasePlugin" />
+		<source-file src="src/android/FirebasePlugin.java" target-dir="src/org/apache/cordova/firebase" />
+		<source-file src="src/android/FirebasePluginInstanceIDService.java" target-dir="src/org/apache/cordova/firebase" />
+		<source-file src="src/android/FirebasePluginMessagingService.java" target-dir="src/org/apache/cordova/firebase" />
 
 		<framework src="src/android/build.gradle" custom="true" type="gradleReference" />
 		<framework src="com.google.firebase:firebase-core:9.0.2" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,16 +27,17 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 			<string name="google_api_key">@string/google_api_key</string>
 		</config-file>
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">
-			<service android:name=".FirebasePluginMessagingService">
+			<service android:name="org.apache.cordova.firebase.FirebasePluginMessagingService">
 				<intent-filter>
 					<action android:name="com.google.firebase.MESSAGING_EVENT"/>
 				</intent-filter>
 			</service>
-			<service android:name=".FirebasePluginInstanceIDService">
+			<service android:name="org.apache.cordova.firebase.FirebasePluginInstanceIDService">
 				<intent-filter>
 					<action android:name="com.google.firebase.INSTANCE_ID_EVENT"/>
 				</intent-filter>
 			</service>
+			<receiver android:name="org.apache.cordova.firebase.OnNotificationOpenReceiver"></receiver>
 		</config-file>
 		<source-file src="src/android/google-services.json" target-dir="." />
 		<source-file src="src/android/FirebasePlugin.java" target-dir="src/org/apache/cordova/firebase" />

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -1,4 +1,4 @@
-package org.apache.cordova.firebase.FirebasePlugin;
+package org.apache.cordova.firebase;
 
 import android.content.Context;
 import android.util.Log;

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -1,6 +1,7 @@
 package org.apache.cordova.firebase;
 
 import android.content.Context;
+import android.content.Intent;
 import android.util.Log;
 import android.os.Bundle;
 
@@ -9,16 +10,22 @@ import org.apache.cordova.CallbackContext;
 
 import org.json.JSONArray;
 import org.json.JSONException;
+import org.json.JSONObject;
 
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.messaging.FirebaseMessaging;
+
+import java.lang.ref.WeakReference;
+import java.util.Set;
 
 
 public class FirebasePlugin extends CordovaPlugin {
 
     private FirebaseAnalytics mFirebaseAnalytics;
     private final String TAG = "FirebasePlugin";
+
+    private static WeakReference<CallbackContext> callbackContext;
 
     @Override
     protected void pluginInitialize() {
@@ -44,6 +51,9 @@ public class FirebasePlugin extends CordovaPlugin {
         } else if (action.equals("unsubscribe")) {
             this.unsubscribe(callbackContext, args.getString(0));
             return true;
+        } else if (action.equals("onNotificationOpen")) {
+            this.registerOnNotificationOpen(callbackContext);
+            return true;
         } else if (action.equals("logEvent")) {
             this.logEvent(callbackContext, args.getString(0), args.getString(1));
             return true;
@@ -51,25 +61,86 @@ public class FirebasePlugin extends CordovaPlugin {
         return false;
     }
 
-    private void getInstanceId(CallbackContext callbackContext) {
-        String token = FirebaseInstanceId.getInstance().getToken();
-        callbackContext.success(token);
+    private void registerOnNotificationOpen(final CallbackContext callbackContext) {
+        FirebasePlugin.callbackContext = new WeakReference<CallbackContext>(callbackContext);
     }
 
-    private void subscribe(CallbackContext callbackContext, String topic) {
-        FirebaseMessaging.getInstance().subscribeToTopic(topic);
-        callbackContext.success();
+    public static void onNotificationOpen(Bundle bundle) {
+        final CallbackContext callbackContext = FirebasePlugin.callbackContext.get();
+        if (callbackContext != null && bundle != null) {
+            JSONObject json = new JSONObject();
+            Set<String> keys = bundle.keySet();
+            for (String key : keys) {
+                try {
+                    json.put(key, bundle.get(key));
+                } catch (JSONException e) {
+                    callbackContext.error(e.getMessage());
+                    return;
+                }
+            }
+
+            callbackContext.success(json);
+        }
     }
 
-    private void unsubscribe(CallbackContext callbackContext, String topic) {
-        FirebaseMessaging.getInstance().unsubscribeFromTopic(topic);
-        callbackContext.success();
+    @Override
+    public void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        FirebasePlugin.onNotificationOpen(intent.getExtras());
     }
 
-    private void logEvent(CallbackContext callbackContext, String key, String value) {
-        Bundle params = new Bundle();
+    private void getInstanceId(final CallbackContext callbackContext) {
+        cordova.getThreadPool().execute(new Runnable() {
+            public void run() {
+                try {
+                    String token = FirebaseInstanceId.getInstance().getToken();
+                    callbackContext.success(token);
+                } catch (Exception e) {
+                    callbackContext.error(e.getMessage());
+                }
+            }
+        });
+    }
+
+    private void subscribe(final CallbackContext callbackContext, final String topic) {
+        cordova.getThreadPool().execute(new Runnable() {
+            public void run() {
+                try {
+                    FirebaseMessaging.getInstance().subscribeToTopic(topic);
+                    callbackContext.success();
+                } catch (Exception e) {
+                    callbackContext.error(e.getMessage());
+                }
+            }
+        });
+    }
+
+    private void unsubscribe(final CallbackContext callbackContext, final String topic) {
+        cordova.getThreadPool().execute(new Runnable() {
+            public void run() {
+                try {
+
+                    FirebaseMessaging.getInstance().unsubscribeFromTopic(topic);
+                    callbackContext.success();
+                } catch (Exception e) {
+                    callbackContext.error(e.getMessage());
+                }
+            }
+        });
+    }
+
+    private void logEvent(final CallbackContext callbackContext, final String key, final String value) {
+        final Bundle params = new Bundle();
         params.putString(key, value);
-        mFirebaseAnalytics.logEvent(key, params);
-        callbackContext.success();
+        cordova.getThreadPool().execute(new Runnable() {
+            public void run() {
+                try {
+                    mFirebaseAnalytics.logEvent(key, params);
+                    callbackContext.success();
+                } catch (Exception e) {
+                    callbackContext.error(e.getMessage());
+                }
+            }
+        });
     }
 }

--- a/src/android/FirebasePluginInstanceIDService.java
+++ b/src/android/FirebasePluginInstanceIDService.java
@@ -1,4 +1,4 @@
-package org.apache.cordova.firebase.FirebasePlugin;
+package org.apache.cordova.firebase;
 
 import android.util.Log;
 

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -52,9 +52,9 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
         Log.d(TAG, "Notification Message Body/Text: " + text);
 
         // TODO: Add option to developer to configure if show notification when app on foreground
-        if (text != null && title != null) {
+        if (!TextUtils.isEmpty(text) || !TextUtils.isEmpty(title)) {
             sendNotification(id, title, text, remoteMessage.getData());
-        }
+         }
     }
 
     private void sendNotification(int id, String title, String messageBody, Map<String, String> data) {

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.media.RingtoneManager;
 import android.net.Uri;
+import android.os.Bundle;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
@@ -57,15 +58,14 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
     }
 
     private void sendNotification(int id, String title, String messageBody, Map<String, String> data) {
-        PackageManager pm = getPackageManager();
-        Intent intent = pm.getLaunchIntentForPackage(getApplicationContext().getPackageName());
-
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        Intent intent = new Intent(this, OnNotificationOpenReceiver.class);
+        Bundle bundle = new Bundle();
         for (String key : data.keySet()) {
-            intent.putExtra(key, data.get(key));
+            bundle.putString(key, data.get(key));
         }
-        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0 /* Request code */, intent,
-                PendingIntent.FLAG_ONE_SHOT);
+        intent.putExtras(bundle);
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(this, 0, intent,
+                PendingIntent.FLAG_UPDATE_CURRENT);
 
         Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
         NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this)

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -1,4 +1,4 @@
-package org.apache.cordova.firebase.FirebasePlugin;
+package org.apache.cordova.firebase;
 
 import android.app.NotificationManager;
 import android.app.PendingIntent;

--- a/src/android/OnNotificationOpenReceiver.java
+++ b/src/android/OnNotificationOpenReceiver.java
@@ -1,0 +1,24 @@
+package org.apache.cordova.firebase;
+
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+
+public class OnNotificationOpenReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        PackageManager pm = context.getPackageManager();
+        Intent launchIntent = pm.getLaunchIntentForPackage(context.getPackageName());
+
+        launchIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+        Bundle data = intent.getExtras();
+        launchIntent.putExtras(data);
+        context.startActivity(launchIntent);
+        FirebasePlugin.onNotificationOpen(data);
+
+    }
+}

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -4,6 +4,10 @@ exports.getInstanceId = function(success, error) {
     exec(success, error, "FirebasePlugin", "getInstanceId", []);
 };
 
+exports.onNotificationOpen = function(success, error) {
+    exec(success, error, "FirebasePlugin", "onNotificationOpen", []);
+};
+
 exports.grantPermission = function(success, error) {
     exec(success, error, "FirebasePlugin", "grantPermission", []);
 };


### PR DESCRIPTION
Hi, I had the time to develop the notificationOpen callback. After developing it I realized one thing... push notifications delivered directly from Firebase (without going through FirebasePluginMessagingService) will not trigger the callback. I would leave a suggestion to always use data notifications for the users of this lib so it will be able to call the callback.
It is not perfect, but it seems to work.

Well, that is the best I can do.
In the device ready callback....The developer will need to register again every time a new notification arrives...
```
private registerForPushOpen(): void {
        if (typeof window.FirebasePlugin !== 'undefined') {
            window.FirebasePlugin.onNotificationOpen((success) => {
                console.log("opening notification");
                console.log(success);
                this.registerForPushOpen();
            }, (error) => {
                console.log("Error trying to register callback");
                console.log(error);
            });
        }
    }
``` 

I fixed, improved a lot of other areas, but once again... I did not touch the iOS code base.
That is all folks.