### PR TITLE
Remote Config implementation for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,113 @@ Log an event using Analytics:
 ```
 window.FirebasePlugin.logEvent("pageLoad", "Dashboard");
 ```
+
+### fetch
+
+Fetch Remote Config parameter values for your app:
+```
+window.FirebasePlugin.fetch();
+// or, specify the cacheExpirationSeconds
+window.FirebasePlugin.fetch(600);
+```
+
+### activateFetched
+
+Activate the Remote Config fetched config:
+```
+window.FirebasePlugin.activateFetched(function(activated) {
+    // activated will be true if there was a fetched config activated,
+    // or false if no fetched config was found, or the fetched config was already activated.
+    console.log(activated);
+}, function(error) {
+    console.error(error);
+});
+```
+
+### getValue
+
+Retrieve a Remote Config value:
+```
+window.FirebasePlugin.getValue("key", function(value) {
+    console.log(value);
+}, function(error) {
+    console.error(error);
+});
+// or, specify a namespace for the config value
+window.FirebasePlugin.getValue("key", "namespace", function(value) {
+    console.log(value);
+}, function(error) {
+    console.error(error);
+});
+```
+
+### getByteArray
+
+Retrieve a Remote Config byte array:
+```
+window.FirebasePlugin.getByteArray("key", function(bytes) {
+    // a Base64 encoded string that represents the value for "key"
+    console.log(bytes.base64);
+    // a numeric array containing the values of the byte array (i.e. [0xFF, 0x00])
+    bytes.array;
+}, function(error) {
+    console.error(error);
+});
+// or, specify a namespace for the byte array
+window.FirebasePlugin.getByteArray("key", "namespace", function(bytes) {
+    // a Base64 encoded string that represents the value for "key"
+    console.log(bytes.base64);
+    // a numeric array containing the values of the byte array (i.e. [0xFF, 0x00])
+    bytes.array;
+}, function(error) {
+    console.error(error);
+});
+```
+
+### getInfo
+
+Get the current state of the FirebaseRemoteConfig singleton object:
+```
+window.FirebasePlugin.getInfo(function(info) {
+    // the status of the developer mode setting (true/false)
+    console.log(info.configSettings.developerModeEnabled);
+    // the timestamp (milliseconds since epoch) of the last successful fetch
+    console.log(info.fetchTimeMillis);
+    // the status of the most recent fetch attempt (int)
+    console.log(info.lastFetchStatus);
+}, function(error) {
+    console.error(error);
+});
+```
+
+### setConfigSettings
+
+Change the settings for the FirebaseRemoteConfig object's operations:
+```
+var settings = {
+    developerModeEnabled: true
+}
+window.FirebasePlugin.setConfigSettings(settings);
+```
+
+### setDefaults
+
+Set defaults in the Remote Config:
+```
+// define defaults
+var defaults = {
+    // map property name to value in Remote Config defaults
+    mLong: 1000,
+    mString: 'hello world',
+    mDouble: 3.14,
+    mBoolean: true,
+    // map "mBase64" to a Remote Config byte array represented by a Base64 string
+    mBase64: "SGVsbG8gV29ybGQ=",
+    // map "mBytes" to a Remote Config byte array represented by a numeric array
+    mBytes: [0xFF, 0x00]
+}
+// set defaults
+window.FirebasePlugin.setDefaults(defaults);
+// or, specify a namespace
+window.FirebasePlugin.setDefaults(defaults, "namespace");
+```

--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ var defaults = {
     mDouble: 3.14,
     mBoolean: true,
     // map "mBase64" to a Remote Config byte array represented by a Base64 string
-    mBase64: "SGVsbG8gV29ybGQ=",
+    // Note: the Base64 string is in an array in order to differentiate from a string config value
+    mBase64: ["SGVsbG8gV29ybGQ="],
     // map "mBytes" to a Remote Config byte array represented by a numeric array
     mBytes: [0xFF, 0x00]
 }

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -39,12 +39,26 @@ exports.fetch = function (cacheExpirationSeconds, success, error) {
     exec(success, error, "FirebasePlugin", "activateFetched", args);
 };
 
-exports.getByteArray = function (key, success, error) {
-    exec(success, error, "FirebasePlugin", "getByteArray", [key]);
+exports.getByteArray = function (key, namespace, success, error) {
+    var args = [key];
+    if (typeof namespace === 'string') {
+        args.push(namespace);
+    } else {
+        error = success;
+        success = namespace;
+    }
+    exec(success, error, "FirebasePlugin", "getByteArray", args);
 };
 
-exports.getValue = function (key, success, error) {
-    exec(success, error, "FirebasePlugin", "getValue", [key]);
+exports.getValue = function (key, namespace, success, error) {
+    var args = [key];
+    if (typeof namespace === 'string') {
+        args.push(namespace);
+    } else {
+        error = success;
+        success = namespace;
+    }
+    exec(success, error, "FirebasePlugin", "getValue", args);
 };
 
 exports.getInfo = function (success, error) {
@@ -55,6 +69,13 @@ exports.setConfigSettings = function (settings, success, error) {
     exec(success, error, "FirebasePlugin", "setConfigSettings", [settings]);
 };
 
-exports.setDefaults = function (defaults, success, error) {
-    exec(success, error, "FirebasePlugin", "setDefaults", [defaults]);
+exports.setDefaults = function (defaults, namespace, success, error) {
+    var args = [defaults];
+    if (typeof namespace === 'string') {
+        args.push(namespace);
+    } else {
+        error = success;
+        success = namespace;
+    }
+    exec(success, error, "FirebasePlugin", "setDefaults", args);
 };

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -24,6 +24,37 @@ exports.logEvent = function(key, value, success, error) {
     exec(success, error, "FirebasePlugin", "logEvent", [key, value]);
 };
 
+exports.activateFetched = function (success, error) {
+    exec(success, error, "FirebasePlugin", "activateFetched", []);
+};
+
+exports.fetch = function (cacheExpirationSeconds, success, error) {
+    var args = [];
+    if (typeof cacheExpirationSeconds === 'number') {
+        args.push(cacheExpirationSeconds);
+    } else {
+        error = success;
+        success = cacheExpirationSeconds;
+    }
+    exec(success, error, "FirebasePlugin", "activateFetched", args);
+};
+
+exports.getByteArray = function (key, success, error) {
+    exec(success, error, "FirebasePlugin", "getByteArray", [key]);
+};
+
+exports.getValue = function (key, success, error) {
+    exec(success, error, "FirebasePlugin", "getValue", [key]);
+};
+
+exports.getInfo = function (success, error) {
+    exec(success, error, "FirebasePlugin", "getInfo", []);
+};
+
+exports.setConfigSettings = function (settings, success, error) {
+    exec(success, error, "FirebasePlugin", "setConfigSettings", [settings]);
+};
+
 exports.setDefaults = function (defaults, success, error) {
     exec(success, error, "FirebasePlugin", "setDefaults", [defaults]);
 };

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -23,3 +23,7 @@ exports.unsubscribe = function(topic, success, error) {
 exports.logEvent = function(key, value, success, error) {
     exec(success, error, "FirebasePlugin", "logEvent", [key, value]);
 };
+
+exports.setDefaults = function (defaults, success, error) {
+    exec(success, error, "FirebasePlugin", "setDefaults", [defaults]);
+};


### PR DESCRIPTION
I was in need of this in one of my apps, so I figured I'd be helpful (or at least try to be) and implement it. I only did the Android portion, as I have not done iOS development before. If I have more time I can look into iOS; this is a relatively simple to plugin that doesn't use the OS much anyway, so I should be able to figure it out given enough time. 

One thing to note is that a single JSON file with default config values could easily be loaded from disk in JavaScript and passed to setDefaults() instead of using 2 different files for Android/iOS. I thought this might be a nice feature and it just sort of worked out that way, which was nice.