### PR TITLE
Adding token refresh callback to make plugin more usable

### DIFF
--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -63,6 +63,8 @@
     
     // Connect to FCM since connection may have failed when attempted before having a token.
     [self connectToFcm];
+
+    [FirebasePlugin.firebasePlugin tokenRefreshNotification:refreshedToken];
 }
 
 - (void)connectToFcm {

--- a/src/ios/FirebasePlugin.h
+++ b/src/ios/FirebasePlugin.h
@@ -10,12 +10,15 @@
 - (void)subscribe:(CDVInvokedUrlCommand*)command;
 - (void)unsubscribe:(CDVInvokedUrlCommand*)command;
 - (void)onNotificationOpen:(CDVInvokedUrlCommand*)command;
+- (void)onTokenRefreshNotification:(CDVInvokedUrlCommand*)command;
 - (void)sendNotification:(NSDictionary*)userInfo;
+- (void)tokenRefreshNotification:(NSString*)token;
 - (void)logEvent:(CDVInvokedUrlCommand*)command;
 - (void)setUserId:(CDVInvokedUrlCommand*)command;
 - (void)setUserProperty:(CDVInvokedUrlCommand*)command;
 
 @property (nonatomic, copy) NSString *notificationCallbackId;
+@property (nonatomic, copy) NSString *tokenRefreshCallbackId;
 @property (nonatomic, retain) NSMutableArray *notificationStack;
 
 @end

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -13,6 +13,7 @@
 @implementation FirebasePlugin
 
 @synthesize notificationCallbackId;
+@synthesize tokenRefreshCallbackId;
 @synthesize notificationStack;
 
 static NSInteger const kNotificationStackSize = 10;
@@ -121,6 +122,14 @@ static FirebasePlugin *firebasePlugin;
     }
 }
 
+- (void)onTokenRefreshNotification:(CDVInvokedUrlCommand *)command {
+    self.tokenRefreshCallbackId = command.callbackId;
+    NSString* currentToken = [[FIRInstanceID instanceID] token];
+    if (currentToken != nil) {
+        [self tokenRefreshNotification:currentToken];
+    }
+}
+
 - (void)sendNotification:(NSDictionary *)userInfo {
     if (self.notificationCallbackId != nil) {
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:userInfo];
@@ -137,6 +146,13 @@ static FirebasePlugin *firebasePlugin;
         if ([self.notificationStack count] >= kNotificationStackSize) {
             [self.notificationStack removeLastObject];
         }
+    }
+}
+
+- (void)tokenRefreshNotification:(NSString *)token {
+    if (self.tokenRefreshCallbackId != nil) {
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:token];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:self.tokenRefreshCallbackId];
     }
 }
 

--- a/www/firebase-browser.js
+++ b/www/firebase-browser.js
@@ -6,6 +6,10 @@ exports.onNotificationOpen = function(success, error) {
     success();
 };
 
+exports.onTokenRefreshNotification = function(success, error) {
+    success();
+};
+
 exports.grantPermission = function(success, error) {
     success();
 };

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -8,6 +8,10 @@ exports.onNotificationOpen = function(success, error) {
     exec(success, error, "FirebasePlugin", "onNotificationOpen", []);
 };
 
+exports.onTokenRefreshNotification = function(success, error) {
+    exec(success, error, "FirebasePlugin", "onTokenRefreshNotification", []);
+};
+
 exports.grantPermission = function(success, error) {
     exec(success, error, "FirebasePlugin", "grantPermission", []);
 };


### PR DESCRIPTION
This should eliminate the need to use the one-time API call of getToken, instead allowing us to subscribe to a 'token refreshed' callback in our JS. The API call to getToken is pretty useless since it could be null, and we don't have a way to listen for changes.