### PR TITLE
Disabled the second replacement of 'google_api_key' value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 *.log
+*.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .DS_Store
 *.log
-*.idea

--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -72,7 +72,10 @@ if (directoryExists("platforms/android")) {
         strings = strings.replace(new RegExp('(\r\n|\n|\r)[ \t]*(\r\n|\n|\r)', "gm"), '$1')
 
         // replace the default value
-        strings = strings.replace(new RegExp('<string name="google_app_id">([^<]+?)</string>', "i"), '<string name="google_app_id">' + json.client[0].client_info.mobilesdk_app_id + '</string>')
+        if(json.client[0].api_key[0] == undefined)
+          console.log('api_key is not available')
+        else
+          strings = strings.replace(new RegExp('<string name="google_api_key">([^<]+?)</string>', "i"), '<string name="google_api_key">' + json.client[0].api_key[0].current_key + '</string>')
 
         // replace the default value
         strings = strings.replace(new RegExp('<string name="google_api_key">([^<]+?)</string>', "i"), '<string name="google_api_key">' + json.client[0].api_key[0].current_key + '</string>')


### PR DESCRIPTION
Hi,
Because there are a lots of posts from developers asking to solve this error: Error: "Invalid data, chunk must be a string or buffer, not object"  and most of times the api_key Array comes empty, I've added an IF checking if this value is undefined or not, if it is, then do nothing.

Thanks,
Dan
