### PR TITLE
Android hardreference contexts

### DIFF
--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -45,8 +45,8 @@ public class FirebasePlugin extends CordovaPlugin {
 
     private static boolean inBackground = true;
     private static ArrayList<Bundle> notificationStack = null;
-    private static WeakReference<CallbackContext> notificationCallbackContext;
-    private static WeakReference<CallbackContext> tokenRefreshCallbackContext;
+    private static CallbackContext notificationCallbackContext;
+    private static CallbackContext tokenRefreshCallbackContext;
 
     @Override
     protected void pluginInitialize() {
@@ -140,7 +140,7 @@ public class FirebasePlugin extends CordovaPlugin {
     }
 
     private void onNotificationOpen(final CallbackContext callbackContext) {
-        FirebasePlugin.notificationCallbackContext = new WeakReference<CallbackContext>(callbackContext);
+        FirebasePlugin.notificationCallbackContext = callbackContext;
         if (FirebasePlugin.notificationStack != null) {
             for (Bundle bundle : FirebasePlugin.notificationStack) {
                 FirebasePlugin.sendNotification(bundle);
@@ -150,7 +150,7 @@ public class FirebasePlugin extends CordovaPlugin {
     }
 
     private void onTokenRefresh(final CallbackContext callbackContext) {
-        FirebasePlugin.tokenRefreshCallbackContext = new WeakReference<CallbackContext>(callbackContext);
+        FirebasePlugin.tokenRefreshCallbackContext = callbackContext;
 
         cordova.getThreadPool().execute(new Runnable() {
             public void run() {
@@ -175,7 +175,7 @@ public class FirebasePlugin extends CordovaPlugin {
             notificationStack.add(bundle);
             return;
         }
-        final CallbackContext callbackContext = FirebasePlugin.notificationCallbackContext.get();
+        final CallbackContext callbackContext = FirebasePlugin.notificationCallbackContext;
         if (callbackContext != null && bundle != null) {
             JSONObject json = new JSONObject();
             Set<String> keys = bundle.keySet();
@@ -198,7 +198,7 @@ public class FirebasePlugin extends CordovaPlugin {
         if(FirebasePlugin.tokenRefreshCallbackContext == null) {
             return;
         }
-        final CallbackContext callbackContext = FirebasePlugin.tokenRefreshCallbackContext.get();
+        final CallbackContext callbackContext = FirebasePlugin.tokenRefreshCallbackContext;
         if (callbackContext != null && token != null) {
             PluginResult pluginresult = new PluginResult(PluginResult.Status.OK, token);
             pluginresult.setKeepCallback(true);
@@ -211,8 +211,7 @@ public class FirebasePlugin extends CordovaPlugin {
     }
 
     public static boolean hasNotificationsCallback() {
-        return FirebasePlugin.notificationCallbackContext != null &&
-                FirebasePlugin.notificationCallbackContext.get() != null;
+        return FirebasePlugin.notificationCallbackContext != null;
     }
 
     @Override

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -67,8 +67,8 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
         Log.d(TAG, "Notification Message Body/Text: " + text);
 
         // TODO: Add option to developer to configure if show notification when app on foreground
-        if (!TextUtils.isEmpty(text) || !TextUtils.isEmpty(title)) {
-            boolean showNotification = FirebasePlugin.inBackground() || !FirebasePlugin.hasNotificationsCallback();
+        if (!TextUtils.isEmpty(text) || !TextUtils.isEmpty(title) || (!remoteMessage.getData().isEmpty())) {
+            boolean showNotification = (FirebasePlugin.inBackground() || !FirebasePlugin.hasNotificationsCallback()) && (!TextUtils.isEmpty(text) || !TextUtils.isEmpty(title));
             sendNotification(id, title, text, remoteMessage.getData(), showNotification);
         }
     }


### PR DESCRIPTION
Changed WeakReference<CallbackContext> to CallbackContext, otherwise notificationCallbackContext becomes null when app goes to sleep.