### PR TITLE
Implement setScreenName method for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ Log an event using Analytics:
 window.FirebasePlugin.logEvent("page_view", {page: "dashboard"});
 ```
 
+### setScreenName
+
+Set the name of the current screen in Analytics:
+```
+window.FirebasePlugin.setScreenName("Home");
+```
+
 ### setUserId
 
 Set a user id for use in Analytics:

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -61,7 +61,6 @@ public class FirebasePlugin extends CordovaPlugin {
                         FirebasePlugin.notificationStack = new ArrayList<Bundle>();
                     }
                     notificationStack.add(extras);
-                    
                 }
             }
         });
@@ -95,6 +94,9 @@ public class FirebasePlugin extends CordovaPlugin {
             return true;
         } else if (action.equals("logEvent")) {
             this.logEvent(callbackContext, args.getString(0), args.getJSONObject(1));
+            return true;
+        } else if (action.equals("setScreenName")) {
+            this.setScreenName(callbackContext, args.getString(0));
             return true;
         } else if (action.equals("setUserId")) {
             this.setUserId (callbackContext, args.getString(0));
@@ -331,6 +333,20 @@ public class FirebasePlugin extends CordovaPlugin {
             public void run() {
                 try {
                     mFirebaseAnalytics.logEvent(name, bundle);
+                    callbackContext.success();
+                } catch (Exception e) {
+                    callbackContext.error(e.getMessage());
+                }
+            }
+        });
+    }
+
+    private void setScreenName(final CallbackContext callbackContext, final String name) {
+        // This must be called on the main thread
+        cordova.getActivity().runOnUiThread(new Runnable() {
+            public void run() {
+                try {
+                    mFirebaseAnalytics.setCurrentScreen(cordova.getActivity(), name, null);
                     callbackContext.success();
                 } catch (Exception e) {
                     callbackContext.error(e.getMessage());

--- a/www/firebase-browser.js
+++ b/www/firebase-browser.js
@@ -52,6 +52,12 @@ exports.logEvent = function(name, params, success, error) {
     }
 };
 
+exports.setScreenName = function(name, success, error) {
+    if (typeof success === 'function') {
+        success();
+    }
+};
+
 exports.setUserId = function(id, success, error) {
     if (typeof success === 'function') {
         success();

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -23,7 +23,7 @@ exports.grantPermission = function(success, error) {
 exports.hasPermission = function(success, error) {
     exec(success, error, "FirebasePlugin", "hasPermission", []);
 };
-               
+
 exports.setBadgeNumber = function(number, success, error) {
     exec(success, error, "FirebasePlugin", "setBadgeNumber", [number]);
 };
@@ -42,6 +42,10 @@ exports.unsubscribe = function(topic, success, error) {
 
 exports.logEvent = function(name, params, success, error) {
     exec(success, error, "FirebasePlugin", "logEvent", [name, params]);
+};
+
+exports.setScreenName = function(name, success, error) {
+    exec(success, error, "FirebasePlugin", "setScreenName", [name]);
 };
 
 exports.setUserId = function(id, success, error) {


### PR DESCRIPTION
Android implementation of a new method "setScreenName". Discussed in the following issue: https://github.com/arnesson/cordova-plugin-firebase/issues/98

The only thing to comment other than the iOS part not being implemented, is that the method had to be called from the main thread, so it couldn't be executed using cordova.getThreadPool(). I couldn't find this documented anywhere, but when I tested this feature on a device I got an error stating "setCurrentScreen must be called from the main thread".