### PR TITLE
Update FirebasePluginMessagingService.java - replace default notificaiton icon, the easy way

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Create the required styles.xml files and add the icons to the
 
 The example below uses a png named "ic_silhouette.png", the app Icon (@mipmap/icon) and sets a base theme.  
 From android version 21 (Lollipop) notifications were changed, needing a seperate setting.  
-If you only Lollipop and above, you don't need to setup both.  
+If you only target Lollipop and above, you don't need to setup both.  
 Thankfully using the version dependant asset selections, we can make one build/apk supporting all target platforms.  
 `<projectroot>/res/native/android/res/values/styles.xml`
 ```

--- a/README.md
+++ b/README.md
@@ -34,11 +34,15 @@ This plugin uses a hook (after prepare) that copies the configuration files to t
 
 ## Changing Notification Icon
 To set a big icon and small icon for notifications, define them through styles.
+
 Create a styles.xml and add the icons to the
-<projectroot>/res/native/android/res/<drawable-DPI> folders
+<projectroot>/res/native/android/res/<drawable-DPI> folders.
+
 The example below uses a png named "ic_silhouette.png" and sets a base theme.
+
 From version 21 notifications were changed, needing a seperate setting. 
 If you only target 21 and above, you don't need to setup both.
+
 Thankfully using the version dependant asset selections, we can make one build/apk supporting all target platforms.
 
 <projectroot>/res/native/android/res/values/styles.xml

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ To set a big icon and small icon for notifications, define them through styles.
 Create a styles.xml and add the icons to the  
 `<projectroot>/res/native/android/res/<drawable-DPI>` folders.  
 
-The example below uses a png named "ic_silhouette.png" and sets a base theme.  
-From version 21 notifications were changed, needing a seperate setting.  
-If you only target 21 and above, you don't need to setup both.  
+The example below uses a png named "ic_silhouette.png", the app Icon (@mipmap/icon) and sets a base theme.  
+From android version 21 (Lollipop) notifications were changed, needing a seperate setting.  
+If you only Lollipop and above, you don't need to setup both.  
 Thankfully using the version dependant asset selections, we can make one build/apk supporting all target platforms.  
 `<projectroot>/res/native/android/res/values/styles.xml`
 ```
@@ -53,7 +53,6 @@ Thankfully using the version dependant asset selections, we can make one build/a
     <drawable name="notification_icon">@mipmap/icon</drawable>
 </resources>
 ```
-
 and  
 `<projectroot>/res/native/android/res/values-v21/styles.xml`
 ```

--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ and
 </resources>
 ```
 
+## Notification Colors
+
+On Android Lollipop and above you can also set the accent color for the notification by adding a color setting.
+
+<projectroot>/res/native/android/res/values/colors.xml
+```
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="primary">#FFFFFF00</color>
+    <color name="primary_dark">#FF220022</color>
+    <color name="accent">#FF00FFFF</color>
+</resources>
+```
+
+
 ### Notes about PhoneGap Build
 
 Hooks does not work with PhoneGap Build. This means you will have to manually make sure the configuration files are included. One way to do that is to make a private fork of this plugin and replace the placeholder config files (see src/ios and src/android) with your actual ones, as well as hard coding your app id and api key in plugin.xml.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ This plugin uses a hook (after prepare) that copies the configuration files to t
 **Note that the Firebase SDK requires the configuration files to be present and valid, otherwise your app will crash on boot or Firebase features won't work.**
 
 ## Changing Notification Icon
-To set a big icon and small icon for notifications, define them through styles.  
-Create a styles.xml and add the icons to the  
+The plugin will use notification_icon from drawable resources if it exists, otherwise the default app icon will is used.
+To set a big icon and small icon for notifications, define them through drawable nodes.  
+Create the required styles.xml files and add the icons to the  
 `<projectroot>/res/native/android/res/<drawable-DPI>` folders.  
 
 The example below uses a png named "ic_silhouette.png", the app Icon (@mipmap/icon) and sets a base theme.  
@@ -136,7 +137,7 @@ Notification flow:
 
 Notification icon on Android:
 
-The plugin will look for and use notification_icon in drawable resources if it exists, otherwise the default app icon will is used. 
+[Changing notification icon](#changing-notification-icon)
 
 ### grantPermission (iOS only)
 

--- a/README.md
+++ b/README.md
@@ -33,19 +33,15 @@ This plugin uses a hook (after prepare) that copies the configuration files to t
 **Note that the Firebase SDK requires the configuration files to be present and valid, otherwise your app will crash on boot or Firebase features won't work.**
 
 ## Changing Notification Icon
-To set a big icon and small icon for notifications, define them through styles.
+To set a big icon and small icon for notifications, define them through styles.  
+Create a styles.xml and add the icons to the  
+`<projectroot>/res/native/android/res/<drawable-DPI>` folders.  
 
-Create a styles.xml and add the icons to the
-<projectroot>/res/native/android/res/<drawable-DPI> folders.
-
-The example below uses a png named "ic_silhouette.png" and sets a base theme.
-
-From version 21 notifications were changed, needing a seperate setting. 
-If you only target 21 and above, you don't need to setup both.
-
-Thankfully using the version dependant asset selections, we can make one build/apk supporting all target platforms.
-
-<projectroot>/res/native/android/res/values/styles.xml
+The example below uses a png named "ic_silhouette.png" and sets a base theme.  
+From version 21 notifications were changed, needing a seperate setting.  
+If you only target 21 and above, you don't need to setup both.  
+Thankfully using the version dependant asset selections, we can make one build/apk supporting all target platforms.  
+`<projectroot>/res/native/android/res/values/styles.xml`
 ```
 <?xml version="1.0" encoding="utf-8" ?>
 <resources>
@@ -58,8 +54,8 @@ Thankfully using the version dependant asset selections, we can make one build/a
 </resources>
 ```
 
-and
-<projectroot>/res/native/android/res/values-v21/styles.xml
+and  
+`<projectroot>/res/native/android/res/values-v21/styles.xml`
 ```
 <?xml version="1.0" encoding="utf-8" ?>
 <resources>
@@ -76,7 +72,7 @@ and
 
 On Android Lollipop and above you can also set the accent color for the notification by adding a color setting.
 
-<projectroot>/res/native/android/res/values/colors.xml
+`<projectroot>/res/native/android/res/values/colors.xml`
 ```
 <?xml version="1.0" encoding="utf-8"?>
 <resources>

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -11,13 +11,13 @@ import android.os.Bundle;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 import android.text.TextUtils;
+import android.app.Notification;
 
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
 import java.util.Map;
 import java.util.Random;
-
 
 public class FirebasePluginMessagingService extends FirebaseMessagingService {
 
@@ -100,15 +100,24 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
                 notificationBuilder.setSmallIcon(getApplicationInfo().icon);
             }
 
-            NotificationManager notificationManager =
-                    (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+            if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP)
+            {
+				int accentID = getResources().getIdentifier("accent", "color", getPackageName());
+                notificationBuilder.setColor(getResources().getColor(accentID, null));				
+            }
+            
+            Notification notification = notificationBuilder.build();
+            if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP){
+				int iconID = android.R.id.icon;
+				int notiID = getResources().getIdentifier("notification_big", "drawable", getPackageName());
+                notification.contentView.setImageViewResource(iconID, notiID);
+            }
+            NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 
-            notificationManager.notify(id.hashCode(), notificationBuilder.build());
+            notificationManager.notify(id.hashCode(), notification);
         } else {
             bundle.putBoolean("tap", false);
             FirebasePlugin.sendNotification(bundle);
         }
     }
-
-
 }


### PR DESCRIPTION
add bigicon and replace small icon using drawables defined in styles.
you can add a styles as well as the drawbles to the 
res/native/android/ folder

values/styles.xml
and 
values-v21/styles.xml

<?xml version="1.0" encoding="utf-8" ?>
<resources>
        <drawable name="notification_big">@mipmap/icon</drawable>
        <drawable name="notification_icon">@drawable/ic_silhouette</drawable>
</recources