### PR TITLE
Relaunch Cordova app if not running

### DIFF
--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -4,7 +4,6 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Bundle;
@@ -106,9 +105,8 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
             notificationManager.notify(id.hashCode(), notificationBuilder.build());
         } else {
             bundle.putBoolean("tap", false);
-            FirebasePlugin.sendNotification(bundle);
+            FirebasePlugin.sendNotification(bundle, this.getApplicationContext());
         }
     }
-
 
 }

--- a/src/android/OnNotificationOpenReceiver.java
+++ b/src/android/OnNotificationOpenReceiver.java
@@ -17,7 +17,7 @@ public class OnNotificationOpenReceiver extends BroadcastReceiver {
         launchIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
         Bundle data = intent.getExtras();
         data.putBoolean("tap", true);
-        FirebasePlugin.sendNotification(data);
+        FirebasePlugin.sendNotification(data, context);
         launchIntent.putExtras(data);
         context.startActivity(launchIntent);
     }


### PR DESCRIPTION
If no notification callback, the MainActivity of the app is launched. With this the app gets the data notification even if swiped out from recent apps list, or phone is rebooted.