### PR TITLE
add support for custom error logs to firebase crash reporting

### DIFF
--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -17,6 +17,7 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfig;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigInfo;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue;
+import com.google.firebase.crash.FirebaseCrash;
 import me.leolin.shortcutbadger.ShortcutBadger;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -96,6 +96,9 @@ public class FirebasePlugin extends CordovaPlugin {
         } else if (action.equals("logEvent")) {
             this.logEvent(callbackContext, args.getString(0), args.getJSONObject(1));
             return true;
+        } else if (action.equals("logError")) {
+            this.logError(callbackContext, args.getString(0));
+            return true;
         } else if (action.equals("setScreenName")) {
             this.setScreenName(callbackContext, args.getString(0));
             return true;
@@ -361,6 +364,21 @@ public class FirebasePlugin extends CordovaPlugin {
                 }
             }
         });
+    }
+
+    private void logError(final CallbackContext callbackContext, final String message) throws JSONException {
+      cordova.getThreadPool().execute(new Runnable() {
+              public void run() {
+                  try {
+                      FirebaseCrash.report(new Exception(message);
+                      callbackContext.success(1);
+                  } catch (Exception e){
+                      FirebaseCrash.log(e.getMessage());
+                      e.printStackTrace();
+                      callbackContext.error(e.getMessage());
+                  }
+              }
+          });
     }
 
     private void setScreenName(final CallbackContext callbackContext, final String name) {

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -99,12 +99,12 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
                 notificationBuilder.setSmallIcon(getApplicationInfo().icon);
             }
 
-            if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.MARSHMALLOW)
+            if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M)
             {
 				int accentID = getResources().getIdentifier("accent", "color", getPackageName());
-                notificationBuilder.setColor(getResources().getColor(accentID, null));				
+                notificationBuilder.setColor(getResources().getColor(accentID, null));
             }
-            
+
             Notification notification = notificationBuilder.build();
             if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP){
 				int iconID = android.R.id.icon;

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -11,4 +11,5 @@ repositories {
 }
 dependencies {
     compile 'me.leolin:ShortcutBadger:1.1.4@aar'
+    compile 'com.google.firebase:firebase-crash:10.2.1'
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -11,5 +11,5 @@ repositories {
 }
 dependencies {
     compile 'me.leolin:ShortcutBadger:1.1.4@aar'
-    compile 'com.google.firebase:firebase-crash:10.2.1'
+    compile 'com.google.firebase:firebase-crash:+'
 }

--- a/www/firebase-browser.js
+++ b/www/firebase-browser.js
@@ -51,7 +51,11 @@ exports.logEvent = function(name, params, success, error) {
         success();
     }
 };
-
+exports.logError = function(message, success, error) {
+    if (typeof success === 'function') {
+        success();
+    }
+};
 exports.setScreenName = function(name, success, error) {
     if (typeof success === 'function') {
         success();

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -44,6 +44,10 @@ exports.logEvent = function(name, params, success, error) {
     exec(success, error, "FirebasePlugin", "logEvent", [name, params]);
 };
 
+exports.logError = function(message, success, error) {
+    exec(success, error, "FirebasePlugin", "logError", [message]);
+};
+
 exports.setScreenName = function(name, success, error) {
     exec(success, error, "FirebasePlugin", "setScreenName", [name]);
 };


### PR DESCRIPTION
this lets you log fatal and non-fatal errors to firebase crash reporting. I have made matching changes for ionic-native and will submit those there if this gets merged here. I've tested this locally in ionic with a custom error handler. Let me know if you want any changes.

at the moment this is only implemented for android not iOS