### PR TITLE
Fix Android N crash when notification.contentView is null

### DIFF
--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -109,7 +109,9 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
             if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP){
 				int iconID = android.R.id.icon;
 				int notiID = getResources().getIdentifier("notification_big", "drawable", getPackageName());
-                notification.contentView.setImageViewResource(iconID, notiID);
+		if (notification.contentView != null) {
+	                notification.contentView.setImageViewResource(iconID, notiID);
+		}
             }
             NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 


### PR DESCRIPTION
> The view that will represent this notification in the notification list (which is pulled down from the status bar). As of N, this field may be null. The notification view is determined by the inputs to Notification.Builder; a custom RemoteViews can optionally be supplied with setCustomContentView(RemoteViews).

https://developer.android.com/reference/android/app/Notification.html#contentView