### PR TITLE
fix for issue #275

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -74,7 +74,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 			<string>production</string>
 		</config-file>
 
-		<resource-file src="src/ios/GoogleService-Info.plist" target="Resources/GoogleService-Info.plist" />
+		<resource-file src="src/ios/GoogleService-Info.plist" target="GoogleService-Info.plist" />
 
 		<header-file src="src/ios/AppDelegate+FirebasePlugin.h" />
 		<source-file src="src/ios/AppDelegate+FirebasePlugin.m" />


### PR DESCRIPTION
GoogleService-Info.plist resource file is copied/referenced in wrong folder since cordova 7.0.0: the <resource-file ... /> statement in plugin.xml copied the GoogleService-Info.plist to "platforms/ios/<project-name>/Resources/Resources" but the after_prepare hook was writing to "platforms/ios/<project-name>/Resources", because of that when running the application a runtime error occured because the empty GoogleService-Info.plist file was referenced in the xcode project.