### PR TITLE
Fix 'plugin create an extra Resources folder inside Resources with an empty google-info.plist'

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -74,7 +74,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 			<string>production</string>
 		</config-file>
 
-		<resource-file src="src/ios/GoogleService-Info.plist" target="Resources/GoogleService-Info.plist" />
+		<resource-file src="src/ios/GoogleService-Info.plist" />
 
 		<header-file src="src/ios/AppDelegate+FirebasePlugin.h" />
 		<source-file src="src/ios/AppDelegate+FirebasePlugin.m" />


### PR DESCRIPTION
The cause  is https://github.com/apache/cordova-ios/pull/310/files.