### PR TITLE
Create the second Resources Folder in ios platform if it doesn't exist

### DIFF
--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -36,6 +36,11 @@ var name = getValue(config, "name")
 if (directoryExists("platforms/ios")) {
   var paths = ["GoogleService-Info.plist", "platforms/ios/www/GoogleService-Info.plist"];
 
+  // create the second Resources folder if it doesn't exist
+  if (!directoryExists("platforms/ios/" + name + "/Resources/Resources")) {
+    fs.mkdirSync("platforms/ios/" + name + "/Resources/Resources");
+  }
+
   for (var i = 0; i < paths.length; i++) {
     if (fileExists(paths[i])) {
       try {


### PR DESCRIPTION
From issue #349 the second Resources folder is not always there. So before we run `fs.writeFileSync("platforms/ios/" + name + "/Resources/Resources/GoogleService-Info.plist", contents)` in line 44 (of the older file), we verify if it exists. 