### PR TITLE
Dont fail activateFetched for iOS if not activated

### DIFF
--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -307,13 +307,7 @@ static FirebasePlugin *firebasePlugin;
      [self.commandDelegate runInBackground:^{
         FIRRemoteConfig* remoteConfig = [FIRRemoteConfig remoteConfig];
          BOOL activated = [remoteConfig activateFetched];
-         CDVPluginResult *pluginResult;
-         if (activated) {
-             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-         } else {
-             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
-         }
-         
+         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:activated];
          [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
      }];
 }


### PR DESCRIPTION
The API says that activateFetched will return the activated boolean either true or false. Previously on iOS only, it failed if not activated.

The Android API is correct: 
https://github.com/arnesson/cordova-plugin-firebase/blob/e85bcd99bf483c9cd62dfe58beb2dfd916bb055f/src/android/FirebasePlugin.java#L449-L450