### PR TITLE
add google-services as framework

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -55,6 +55,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		<source-file src="src/android/colors.xml" target-dir="res/values" />
 
 		<framework src="src/android/build.gradle" custom="true" type="gradleReference" />
+		<framework src="com.google.android.gms:google-play-services:+" />
 		<framework src="com.google.firebase:firebase-core:+" />
 		<framework src="com.google.firebase:firebase-messaging:+" />
 		<framework src="com.google.firebase:firebase-crash:+" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -55,7 +55,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		<source-file src="src/android/colors.xml" target-dir="res/values" />
 
 		<framework src="src/android/build.gradle" custom="true" type="gradleReference" />
-		<framework src="com.google.android.gms:google-play-services:+" />
+		<framework src="com.google.gms:google-services:+" />
 		<framework src="com.google.firebase:firebase-core:+" />
 		<framework src="com.google.firebase:firebase-messaging:+" />
 		<framework src="com.google.firebase:firebase-crash:+" />


### PR DESCRIPTION
I don't understand why other people aren't running into the same run-time error I was. 
I would get an error from GooglePlayServicesUtil that "The Google Play services resources were not found..."

Adding it as a framework was a recommended technique by other plugins to avoid conflicts between plugins.
I haven't fully tested the plugin integration into my app, but I have confirmed the plugin is loaded.