### PR TITLE
fix ios GoogleService-Info.plist path

### DIFF
--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -16,8 +16,8 @@ var ANDROID_DIR = 'platforms/android';
 var PLATFORM = {
     IOS: {
         dest: [
-            IOS_DIR + name + '/Resources/GoogleService-Info.plist',
-            IOS_DIR + name + '/Resources/Resources/GoogleService-Info.plist'
+            IOS_DIR + '/' + name + '/Resources/GoogleService-Info.plist',
+            IOS_DIR + '/' + name + '/Resources/Resources/GoogleService-Info.plist'
         ],
         src: [
             'GoogleService-Info.plist',


### PR DESCRIPTION
Once you run command 'cordova prepare ios', It will create a new directory in platforms which name like 'iosExample'.
So when you do a cordova build, you will get the below error.
"Error: Your iosExample platform does not have Api.js"