### PR TITLE
Fix #410: Not working on android

### DIFF
--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -52,13 +52,6 @@ var PLATFORM = {
     }
 };
 
-// Copy key files to their platform specific folders
-if (directoryExists(IOS_DIR)) {
-    copyKey(PLATFORM.IOS);
-} else if (directoryExists(ANDROID_DIR)) {
-    copyKey(PLATFORM.ANDROID, updateStringsXml)
-}
-
 function updateStringsXml(contents) {
     var json = JSON.parse(contents);
     var strings = fs.readFileSync(PLATFORM.ANDROID.stringsXml).toString();
@@ -132,3 +125,17 @@ function directoryExists(path) {
         return false;
     }
 }
+
+module.exports = function(context) {
+  //get platform from the context supplied by cordova
+  var platforms = context.opts.platforms;
+  // Copy key files to their platform specific folders
+  if (platforms.indexOf('ios') !== -1 && directoryExists(IOS_DIR)) {
+    console.log('Preparing Firebase on iOS');
+    copyKey(PLATFORM.IOS);
+  }
+  if (platforms.indexOf('android') !== -1 && directoryExists(ANDROID_DIR)) {
+    console.log('Preparing Firebase on Android');
+    copyKey(PLATFORM.ANDROID, updateStringsXml)
+  }
+};


### PR DESCRIPTION
If Android and iOS were configured platforms, the android after_prepare script was not run properly on android. This is fixed by switching from one “if else” to two ”if” clauses and using the cordova context to determine the platform we are currently running at.
by making sure the script is run properly even when iOS and android are configured.