### PR TITLE
Fix for Proguard build error

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -55,7 +55,6 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		<source-file src="src/android/colors.xml" target-dir="res/values" />
 
 		<framework src="src/android/build.gradle" custom="true" type="gradleReference" />
-		<framework src="com.google.gms:google-services:+" />
 		<framework src="com.google.android.gms:play-services-tagmanager:+" />
 		<framework src="com.google.firebase:firebase-core:+" />
 		<framework src="com.google.firebase:firebase-messaging:+" />


### PR DESCRIPTION
If `com.google.gms:google-services` library is referenced, release build with ProGuard minification step fails with a long list of errors:

```
Warning:com.google.gms.googleservices.GoogleServicesPlugin: can't find superclass or interface org.gradle.api.Plugin
Warning:com.google.gms.googleservices.GoogleServicesPlugin: can't find superclass or interface groovy.lang.GroovyObject
Warning:com.google.gms.googleservices.GoogleServicesPlugin$PluginType: can't find superclass or interface groovy.lang.GroovyObject
...
Warning:there were 535 unresolved references to classes or interfaces.
Warning:there were 2 unresolved references to program class members.
Warning:Exception while processing task java.io.IOException: Please correct the above warnings first.
Error:Execution failed for task ':transformClassesAndResourcesWithProguardForRelease'.
```

In [official Firebase documentation](https://firebase.google.com/docs/android/setup) there's no mention that this library needs to be included in Gradle build file as a compile dependency.

After I removed it, the build succeeded and the `getToken` call from the application still returned a token as expected.