### PR TITLE
Update delegate message call

### DIFF
--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -118,7 +118,7 @@ static FirebasePlugin *firebasePlugin;
 			if ( ![NSThread isMainThread] ) {
 				dispatch_sync(dispatch_get_main_queue(), ^{
 					[[UNUserNotificationCenter currentNotificationCenter] setDelegate:self];
-					[[FIRMessaging messaging] setRemoteMessageDelegate:self];
+					[[FIRMessaging messaging] setDelegate:self];
 					[[UIApplication sharedApplication] registerForRemoteNotifications];
 
 					CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus: granted ? CDVCommandStatus_OK : CDVCommandStatus_ERROR];
@@ -127,7 +127,7 @@ static FirebasePlugin *firebasePlugin;
 			}
 			else {
 				[[UNUserNotificationCenter currentNotificationCenter] setDelegate:self];
-				[[FIRMessaging messaging] setRemoteMessageDelegate:self];
+				[[FIRMessaging messaging] setDelegate:self];
 				[[UIApplication sharedApplication] registerForRemoteNotifications];
 				CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
 				[self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];


### PR DESCRIPTION
remoteMessageDelegate is deprecated, should use FIRMessagingDelegate delegate functions.
More info on  https://github.com/arnesson/cordova-plugin-firebase/issues/463