### PR TITLE
Register as delegate and proxy calls

### DIFF
--- a/src/ios/AppDelegate+FirebasePlugin.h
+++ b/src/ios/AppDelegate+FirebasePlugin.h
@@ -1,5 +1,12 @@
 #import "AppDelegate.h"
 
+#if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
+@import UserNotifications;
+#endif
+
 @interface AppDelegate (FirebasePlugin)
 @property (nonatomic, strong) NSNumber *applicationInBackground;
+#if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
+@property (NS_NONATOMIC_IOSONLY, nullable, weak) id <UNUserNotificationCenterDelegate> delegate;
+#endif
 @end

--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -60,12 +60,6 @@
         // For iOS 10 display notification (sent via APNS)
         self.delegate = [UNUserNotificationCenter currentNotificationCenter].delegate;
         [UNUserNotificationCenter currentNotificationCenter].delegate = self;
-        UNAuthorizationOptions authOptions =
-                UNAuthorizationOptionAlert
-                        | UNAuthorizationOptionSound
-                        | UNAuthorizationOptionBadge;
-        [[UNUserNotificationCenter currentNotificationCenter] requestAuthorizationWithOptions:authOptions completionHandler:^(BOOL granted, NSError * _Nullable error) {
-        }];
     #endif
 
     return YES;

--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -16,13 +16,24 @@
 #endif
 
 #define kApplicationInBackgroundKey @"applicationInBackground"
+#define kDelegateKey @"delegate"
 
 @implementation AppDelegate (FirebasePlugin)
+
+@dynamic delegate;
 
 + (void)load {
     Method original = class_getInstanceMethod(self, @selector(application:didFinishLaunchingWithOptions:));
     Method swizzled = class_getInstanceMethod(self, @selector(application:swizzledDidFinishLaunchingWithOptions:));
     method_exchangeImplementations(original, swizzled);
+}
+
+- (void)setDelegate:(id)delegate {
+    objc_setAssociatedObject(self, kDelegateKey, delegate, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (id)delegate {
+    return objc_getAssociatedObject(self, kDelegateKey);
 }
 
 - (void)setApplicationInBackground:(NSNumber *)applicationInBackground {
@@ -35,16 +46,28 @@
 
 - (BOOL)application:(UIApplication *)application swizzledDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     [self application:application swizzledDidFinishLaunchingWithOptions:launchOptions];
-    
+
     if(![FIRApp defaultApp]) {
         [FIRApp configure];
     }
-    
+
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(tokenRefreshNotification:)
                                                  name:kFIRInstanceIDTokenRefreshNotification object:nil];
-    
+
     self.applicationInBackground = @(YES);
-    
+
+    #if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
+        // For iOS 10 display notification (sent via APNS)
+        self.delegate = [UNUserNotificationCenter currentNotificationCenter].delegate;
+        [UNUserNotificationCenter currentNotificationCenter].delegate = self;
+        UNAuthorizationOptions authOptions =
+                UNAuthorizationOptionAlert
+                        | UNAuthorizationOptionSound
+                        | UNAuthorizationOptionBadge;
+        [[UNUserNotificationCenter currentNotificationCenter] requestAuthorizationWithOptions:authOptions completionHandler:^(BOOL granted, NSError * _Nullable error) {
+        }];
+    #endif
+
     return YES;
 }
 
@@ -65,7 +88,7 @@
     // should be done.
     NSString *refreshedToken = [[FIRInstanceID instanceID] token];
     NSLog(@"InstanceID token: %@", refreshedToken);
-    
+
     // Connect to FCM since connection may have failed when attempted before having a token.
     [self connectToFcm];
 
@@ -86,12 +109,12 @@
 
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo {
     NSDictionary *mutableUserInfo = [userInfo mutableCopy];
-    
+
     [mutableUserInfo setValue:self.applicationInBackground forKey:@"tap"];
-    
+
     // Pring full message.
     NSLog(@"%@", mutableUserInfo);
-    
+
     [FirebasePlugin.firebasePlugin sendNotification:mutableUserInfo];
 }
 
@@ -99,12 +122,12 @@
     fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 
     NSDictionary *mutableUserInfo = [userInfo mutableCopy];
-    
+
     [mutableUserInfo setValue:self.applicationInBackground forKey:@"tap"];
-    
+
     // Pring full message.
     NSLog(@"%@", mutableUserInfo);
-    
+
     [FirebasePlugin.firebasePlugin sendNotification:mutableUserInfo];
 }
 
@@ -113,13 +136,39 @@
        willPresentNotification:(UNNotification *)notification
          withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
     NSDictionary *mutableUserInfo = [notification.request.content.userInfo mutableCopy];
-    
+
     [mutableUserInfo setValue:self.applicationInBackground forKey:@"tap"];
-    
-    // Pring full message.
+
+    // Print full message.
     NSLog(@"%@", mutableUserInfo);
-    
+
+    if (![notification.request.trigger isKindOfClass:UNPushNotificationTrigger.class]) {
+        [self.delegate userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
+        return;
+    }
+
     [FirebasePlugin.firebasePlugin sendNotification:mutableUserInfo];
+}
+
+// Handle notification messages after display notification is tapped by the user.
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+didReceiveNotificationResponse:(UNNotificationResponse *)response
+         withCompletionHandler:(void(^)(void))completionHandler {
+    NSDictionary *mutableUserInfo = [response.notification.request.content.userInfo mutableCopy];
+
+    [mutableUserInfo setValue:@YES forKey:@"tap"];
+
+    // Print full message.
+    NSLog(@"Response %@", mutableUserInfo);
+
+    if (![response.notification.request.trigger isKindOfClass:UNPushNotificationTrigger.class]) {
+        [self.delegate userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
+        return;
+    }
+
+    [FirebasePlugin.firebasePlugin sendNotification:mutableUserInfo];
+
+    completionHandler();
 }
 
 // Receive data message on iOS 10 devices.


### PR DESCRIPTION
- Saves reference to previous registered delegate
- Proxies all notifications to other delegate

iOS 10 willPresentNotification was not yet used because the plugin did not register as a delegate.

In order to not override a delegate it saves a reference to that previous delegate so it can proxy notifications that are not remote push notifications. This is needed if used in combination with cordova-plugin-local-notifications.