### PR TITLE
Update after_prepare.js for cordova-android 7+

### DIFF
--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -25,7 +25,7 @@ var config = fs.readFileSync('config.xml').toString();
 var name = getValue(config, 'name');
 
 var IOS_DIR = 'platforms/ios';
-var ANDROID_DIR = 'platforms/android';
+var ANDROID_DIR = directoryExists('platforms/android/app/src/main') ? 'platforms/android/app/src/main' : 'platforms/android';
 
 var PLATFORM = {
     IOS: {


### PR DESCRIPTION
Cordova-android 7 and up got a new directory structure -> new path needed
old: 'platforms/android'
new: 'platforms/android/app/src/main'
using existing `directoryExists` to enable fallback for old projects