### PR TITLE
Closes #549 #558 Parameterized cordova android version during plugin installation

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -5,7 +5,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 	<name>Google Firebase Plugin</name>
 
 	<license>MIT</license>
-
+	<preference name="ANDROID_VERSION" />
 	<engines>
 		<engine name="cordova" version=">=3.2.0" />
 	</engines>

--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -54,7 +54,7 @@ var PLATFORM = {
             ANDROID_DIR + '/assets/www/google-services.json',
             'www/google-services.json'
         ],
-        stringsXml: ANDROID_DIR + '/res/values/strings.xml'
+        stringsXml: ANDROID_DIR + STRING_XML_PATH
     }
 };
 

--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -23,9 +23,15 @@ fs.ensureDirSync = function (dir) {
 
 var config = fs.readFileSync('config.xml').toString();
 var name = getValue(config, 'name');
+var androidVersion = getPreferenceValue(config,"ANDROID_VERSION");
 
 var IOS_DIR = 'platforms/ios';
 var ANDROID_DIR = 'platforms/android';
+var STRING_XML_PATH = '/res/values/strings.xml';
+
+if(androidVersion == "7x") {
+	STRING_XML_PATH = '/app/src/main/res/values/strings.xml';
+}
 
 var PLATFORM = {
     IOS: {
@@ -104,6 +110,15 @@ function copyKey(platform, callback) {
 function getValue(config, name) {
     var value = config.match(new RegExp('<' + name + '>(.*?)</' + name + '>', 'i'));
     if (value && value[1]) {
+        return value[1]
+    } else {
+        return null
+    }
+}
+
+function getPreferenceValue(config, name) {
+    var value = config.match(new RegExp('name="' + name + '" value="(.*?)"', "i"))
+    if(value && value[1]) {
         return value[1]
     } else {
         return null


### PR DESCRIPTION
During plugin installation, we have to specify a new variable named "**ANDROID_VERSION**". If its value is "**7x**" which corresponds to latest cordova android version, then the latest path changes as per https://cordova.apache.org/announcements/2017/12/04/cordova-android-7.0.0.html will be considered. Else the old path will be retained as is.

Installation command for cordova android version 7 and above:
"**cordova plugin add cordova-plugin-firebase --variable ANDROID_VERSION=7x --save**"

Installation command for cordova android version 6 and below:
"**cordova plugin add cordova-plugin-firebase --variable ANDROID_VERSION=6x --save**"