### PR TITLE
Moved setScreenName to the main thread on iOS

### DIFF
--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -263,14 +263,12 @@ static FirebasePlugin *firebasePlugin;
 }
 
 - (void)setScreenName:(CDVInvokedUrlCommand *)command {
-    [self.commandDelegate runInBackground:^{
-        NSString* name = [command.arguments objectAtIndex:0];
- 
-        [FIRAnalytics setScreenName:name screenClass:NULL];
+    NSString* name = [command.arguments objectAtIndex:0];
 
-        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-    }];
+    [FIRAnalytics setScreenName:name screenClass:NULL];
+
+    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void)setUserId:(CDVInvokedUrlCommand *)command {


### PR DESCRIPTION
I ran into an issue where setScreenName was working on Android but not iOS. The FIRAnalytics documentation mentioned that setScreenName must be called on the main thread, so I moved the call to the main thread. Now setScreenName appears to be working on iOS.