### PR TITLE
Fix for required notification channel on Oreo

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -48,6 +48,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 			<receiver android:name="org.apache.cordova.firebase.OnNotificationOpenReceiver"></receiver>
 		</config-file>
 		<resource-file src="src/android/google-services.json" target="."/>
+		<resource-file src="src/android/cordova-plugin-firebase-strings.xml" target="res/values/cordova-plugin-firebase-strings.xml" />
 		<source-file src="src/android/FirebasePlugin.java" target-dir="src/org/apache/cordova/firebase" />
 		<source-file src="src/android/OnNotificationOpenReceiver.java" target-dir="src/org/apache/cordova/firebase" />
 		<source-file src="src/android/FirebasePluginInstanceIDService.java" target-dir="src/org/apache/cordova/firebase" />

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -1,5 +1,6 @@
 package org.apache.cordova.firebase;
 
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
@@ -13,6 +14,7 @@ import android.app.Notification;
 import android.text.TextUtils;
 import android.content.ContentResolver;
 
+import com.asb360.area.dev.R;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
@@ -93,8 +95,10 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
             PendingIntent pendingIntent = PendingIntent.getBroadcast(this, id.hashCode(), intent,
                 PendingIntent.FLAG_UPDATE_CURRENT);
 
+            String channelId = getString(R.string.default_notification_channel_id);
+            String channelName = getString(R.string.default_notification_channel_name);
             Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
-            NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this)
+            NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, channelId)
                 .setContentTitle(title)
                 .setContentText(messageBody)
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
@@ -135,6 +139,14 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
                 }
             }
             NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+
+            // Since android Oreo notification channel is needed.
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+              NotificationChannel channel = new NotificationChannel(channelId,
+                channelName,
+                NotificationManager.IMPORTANCE_DEFAULT);
+              notificationManager.createNotificationChannel(channel);
+            }
 
             notificationManager.notify(id.hashCode(), notification);
         } else {

--- a/src/android/cordova-plugin-firebase-strings.xml
+++ b/src/android/cordova-plugin-firebase-strings.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <string name="default_notification_channel_id">fcm_default_channel</string>
+    <string name="default_notification_channel_name">Default</string>
+</resources>


### PR DESCRIPTION
This fixes the issue seen in #568. Oreo requires notifications to have a channel, this sets a default channel, rather than needing to target an older API. Adds a new strings XML file containing a channel ID and human readable name.