### PR TITLE
fixing cordova-android^7.0.0 compatability

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -31,7 +31,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 				<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 				<uses-permission android:name="android.permission.WAKE_LOCK" />
 		</config-file>
-		<config-file target="AndroidManifest.xml" parent="/manifest/application">
+		<config-file target="app/src/main/AndroidManifest.xml" parent="/manifest/application">
 			<service android:enabled="true" android:exported="false" android:name="com.google.android.gms.measurement.AppMeasurementService" />
 		</config-file>
 		<config-file target="app/src/main/AndroidManifest.xml" parent="/manifest/application">


### PR DESCRIPTION
https://cordova.apache.org/announcements/2017/12/04/cordova-android-7.0.0.html

yes it sadly does break compatibility for pre cordova-android pre 7.0, however without this the plugin will not work for 7+ (cordova-android is now on 7.1.0)

this is a dupe of the [now closed] #587 with the mode=merge removed as only edit-config (not config-file) actually has that xml key.