### PR TITLE
iOS: setScreenName must be called on the main thread.

### DIFF
--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -265,7 +265,7 @@ static FirebasePlugin *firebasePlugin;
 
 - (void)logError:(CDVInvokedUrlCommand *)command {
     [self.commandDelegate runInBackground:^{
-        NSString* errorMessage = [command.arguments objectAtIndex:0];       
+        NSString* errorMessage = [command.arguments objectAtIndex:0];
         FIRCrashLog(@"%@", errorMessage);
         assert(NO);
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
@@ -274,14 +274,12 @@ static FirebasePlugin *firebasePlugin;
 }
 
 - (void)setScreenName:(CDVInvokedUrlCommand *)command {
-    [self.commandDelegate runInBackground:^{
-        NSString* name = [command.arguments objectAtIndex:0];
- 
-        [FIRAnalytics setScreenName:name screenClass:NULL];
+    NSString* name = [command.arguments objectAtIndex:0];
 
-        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-    }];
+    [FIRAnalytics setScreenName:name screenClass:NULL];
+
+    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void)setUserId:(CDVInvokedUrlCommand *)command {


### PR DESCRIPTION
It looks like the merge of Pull Request #594 lost this part of JonSmart's change. Without it the specified screen name is not sent to Firebase Analytics.

Undoing commit afb93d289e0b0cb07a775019c1e7a45dab10e4a5
Reapplying commit 01849ffa6f73a964bc2b1097f460a2eaf5e12b2c