### PR TITLE
Add support for custom message receivers for Android.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -53,6 +53,8 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		<source-file src="src/android/OnNotificationOpenReceiver.java" target-dir="src/org/apache/cordova/firebase" />
 		<source-file src="src/android/FirebasePluginInstanceIDService.java" target-dir="src/org/apache/cordova/firebase" />
 		<source-file src="src/android/FirebasePluginMessagingService.java" target-dir="src/org/apache/cordova/firebase" />
+		<source-file src="src/android/FirebasePluginMessageReceiver.java" target-dir="src/org/apache/cordova/firebase" />
+		<source-file src="src/android/FirebasePluginMessageReceiverManager.java" target-dir="src/org/apache/cordova/firebase" />
 		<source-file src="src/android/colors.xml" target-dir="res/values" />
 
 		<framework src="src/android/build.gradle" custom="true" type="gradleReference" />

--- a/src/android/FirebasePluginMessageReceiver.java
+++ b/src/android/FirebasePluginMessageReceiver.java
@@ -1,0 +1,16 @@
+package org.apache.cordova.firebase;
+
+import com.google.firebase.messaging.RemoteMessage;
+
+public abstract class FirebasePluginMessageReceiver {
+    public FirebasePluginMessageReceiver(){
+        FirebasePluginMessageReceiverManager.register(this);
+    }
+
+    /**
+     * Concrete subclasses should override this and return true if they handle the received message.
+     * @param remoteMessage
+     * @return true if the received message was handled by the receiver so should not be handled by FirebasePlugin.
+     */
+    public abstract boolean onMessageReceived(RemoteMessage remoteMessage);
+}

--- a/src/android/FirebasePluginMessageReceiverManager.java
+++ b/src/android/FirebasePluginMessageReceiverManager.java
@@ -1,0 +1,25 @@
+package org.apache.cordova.firebase;
+
+import com.google.firebase.messaging.RemoteMessage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FirebasePluginMessageReceiverManager {
+    private static List<FirebasePluginMessageReceiver> receivers = new ArrayList<>();
+
+    public static void register(FirebasePluginMessageReceiver receiver){
+        receivers.add(receiver);
+    }
+
+    public static boolean onMessageReceived(RemoteMessage remoteMessage){
+        boolean handled = false;
+        for(FirebasePluginMessageReceiver receiver : receivers){
+            boolean wasHandled = receiver.onMessageReceived(remoteMessage);
+            if(wasHandled){
+                handled = true;
+            }
+        }
+        return handled;
+    }
+}

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -53,6 +53,13 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
         // messages. For more see: https://firebase.google.com/docs/cloud-messaging/concept-options
         // [END_EXCLUDE]
 
+        // Pass the message to the receiver manager so any registered receivers can decide to handle it
+        boolean wasHandled = FirebasePluginMessageReceiverManager.onMessageReceived(remoteMessage);
+        if(wasHandled){
+            Log.d(TAG, "Message was handled by a registered receiver");
+            return; // don't process the message in this method
+        }
+
         // TODO(developer): Handle FCM messages here.
         // Not getting messages here? See why this may be: https://goo.gl/39bRNJ
         String title;


### PR DESCRIPTION
This PR enables other plugins to register as receivers for FCM messages while still supporting the default implementation of this plugin.

I've created a example app which illustrates how a [custom receiver](https://github.com/dpa99c/cordova-plugin-firebase-receiver-test/blob/master/plugins/cordova-plugin-customfcmreceiver/src/CustomFCMReceiverPlugin.java#L75) can be implemented:
https://github.com/dpa99c/cordova-plugin-firebase-receiver-test

My use case: I have a Cordova app which already uses `cordova-plugin-firebase` to receive and display push notifications. However, there's now a requirement to integrate a 3rd party Android SDK which uses FCM data messages for remote management. With the existing version of `cordova-plugin-firebase`, all FCM messages are processed by the plugin with no opportunity to handle them elsewhere since you can only have [1 service per intent-filter on Android](https://stackoverflow.com/a/8606179/777265). This PR makes it possible to handle those specific FCM messages differently while still supporting the standard handling provided by this plugin.