### PR TITLE
[fix] fix google services dependencies conflicts

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -58,6 +58,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		<source-file src="src/android/colors.xml" target-dir="res/values" />
 
 		<framework src="src/android/build.gradle" custom="true" type="gradleReference" />
+		<framework src="src/android/build-extras.gradle" custom="true" type="gradleReference" />
 		<framework src="com.google.gms:google-services:+" />
 		<framework src="com.google.android.gms:play-services-tagmanager:+" />
 		<framework src="com.google.firebase:firebase-core:+" />

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -1,1 +1,21 @@
-apply plugin: 'com.google.gms.google-services'
+allprojects {
+    repositories {
+        //start here
+        configurations.all {
+            resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+                def requested = details.requested
+                if (requested.group == 'com.google.android.gms') {
+                    details.useVersion '11.8.0'
+                }
+                if (requested.group == 'com.google.firebase') {
+                    details.useVersion '11.8.0'
+                }
+            }
+        }
+        //end
+        jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
+    }
+}


### PR DESCRIPTION
In some cases google services dependencies use by two plugins are in conflict

example

```bash
cordova platform add  android
cordova plugin add cordova-plugin-firebase
cordova plugin add cordova-plugin-request-location-accuracy
cordova prepare android
cordova build android

````
cause error:

`error: cannot access zzbfm
ResultCallback {
^
class file for com.google.android.gms.internal.zzbfm not found

See issues: #651 , #614, #612, #610 , #604, #489 

This pretty solution is from @codesundar [comment #612](https://github.com/arnesson/cordova-plugin-firebase/issues/612#issuecomment-376217404)

And fix google play services and firebase dependencies version to 11.8.0  

The use of a build-extras.gradle in cordova is explain here [cordova build-extras.gradle](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#extending-buildgradle)

