### PR TITLE
Added callback for instantVerification

### DIFF
--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -667,8 +667,7 @@ public class FirebasePlugin extends CordovaPlugin {
                             // 2 - Auto-retrieval. On some devices Google Play services can automatically
                             //     detect the incoming verification SMS and perform verificaiton without
                             //     user action.
-                            Log.d(TAG,
-                                    "success: verifyPhoneNumber.onVerificationCompleted - callback and create a custom JWT Token on server and sign in with custom token - we cant do anything");
+                            Log.d(TAG, "success: verifyPhoneNumber.onVerificationCompleted - callback and create a custom JWT Token on server and sign in with custom token - we cant do anything");
 
                             JSONObject returnResults = new JSONObject();
                             try {
@@ -681,9 +680,6 @@ public class FirebasePlugin extends CordovaPlugin {
                             PluginResult pluginresult = new PluginResult(PluginResult.Status.OK, returnResults);
                             pluginresult.setKeepCallback(true);
                             callbackContext.sendPluginResult(pluginresult);
-
-                            // does this fire in cordova?
-                            // YES IT DOES!
                         }
 
                         @Override

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -713,7 +713,6 @@ public class FirebasePlugin extends CordovaPlugin {
                             try {
                                 returnResults.put("verificationId", verificationId);
                                 returnResults.put("instantVerification", false);
-                                //returnResults.put("forceResendingToken", token); // TODO: return forceResendingToken
                             } catch (JSONException e) {
                                 callbackContext.error(e.getMessage());
                                 return;
@@ -729,10 +728,6 @@ public class FirebasePlugin extends CordovaPlugin {
                             TimeUnit.SECONDS, // Unit of timeout
                             cordova.getActivity(), // Activity (for callback binding)
                             mCallbacks); // OnVerificationStateChangedCallbacks
-                    //resentToken);         // The ForceResendingToken obtained from onCodeSent callback
-                    // to force re-sending another verification SMS before the auto-retrieval timeout.
-                    // TODO: make resendToken accessible
-
                 } catch (Exception e) {
                     callbackContext.error(e.getMessage());
                 }

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -668,13 +668,12 @@ public class FirebasePlugin extends CordovaPlugin {
                             //     detect the incoming verification SMS and perform verificaiton without
                             //     user action.
                             Log.d(TAG,
-                                    "success: verifyPhoneNumber.onVerificationCompleted - doing nothing. sign in with token from onCodeSent");
+                                    "success: verifyPhoneNumber.onVerificationCompleted - callback and create a custom JWT Token on server and sign in with custom token - we cant do anything");
 
                             JSONObject returnResults = new JSONObject();
                             try {
                                 returnResults.put("verificationId", false);
                                 returnResults.put("instantVerification", true);
-                                //returnResults.put("forceResendingToken", token); // TODO: return forceResendingToken
                             } catch (JSONException e) {
                                 callbackContext.error(e.getMessage());
                                 return;
@@ -684,7 +683,7 @@ public class FirebasePlugin extends CordovaPlugin {
                             callbackContext.sendPluginResult(pluginresult);
 
                             // does this fire in cordova?
-                            // TODO: return credential
+                            // YES IT DOES!
                         }
 
                         @Override

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -670,6 +670,19 @@ public class FirebasePlugin extends CordovaPlugin {
                             Log.d(TAG,
                                     "success: verifyPhoneNumber.onVerificationCompleted - doing nothing. sign in with token from onCodeSent");
 
+                            JSONObject returnResults = new JSONObject();
+                            try {
+                                returnResults.put("verificationId", false);
+                                returnResults.put("instantVerification", true);
+                                //returnResults.put("forceResendingToken", token); // TODO: return forceResendingToken
+                            } catch (JSONException e) {
+                                callbackContext.error(e.getMessage());
+                                return;
+                            }
+                            PluginResult pluginresult = new PluginResult(PluginResult.Status.OK, returnResults);
+                            pluginresult.setKeepCallback(true);
+                            callbackContext.sendPluginResult(pluginresult);
+
                             // does this fire in cordova?
                             // TODO: return credential
                         }
@@ -704,6 +717,7 @@ public class FirebasePlugin extends CordovaPlugin {
                             JSONObject returnResults = new JSONObject();
                             try {
                                 returnResults.put("verificationId", verificationId);
+                                returnResults.put("instantVerification", false);
                                 //returnResults.put("forceResendingToken", token); // TODO: return forceResendingToken
                             } catch (JSONException e) {
                                 callbackContext.error(e.getMessage());


### PR DESCRIPTION
fixes #623

Android can auto retrieve SMS send trough firebase. Some devices won't even get any SMS when they got verified instantly trough google servers. In this case, this plugin is pretty helpless as it can't do anything (there are better plugins outside like https://github.com/chemerisuk/cordova-plugin-firebase-authentication). You will need to call signInWithCustomToken() instead of creating a credential based on verificationId and code (as you wont have id nor code).

This PR will give proper callbacks (instantVerification: true or false).