### PR TITLE
co-existence with cordova-plugin-local-notification on iOS

### DIFF
--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -142,8 +142,7 @@
               willPresentNotification:notification
                 withCompletionHandler:completionHandler];
 
-    UNNotificationRequest* toast = notification.request;
-    if (![toast.trigger isKindOfClass:UNPushNotificationTrigger.class])
+    if (![notification.request.trigger isKindOfClass:UNPushNotificationTrigger.class])
         return;
     
     NSDictionary *mutableUserInfo = [notification.request.content.userInfo mutableCopy];
@@ -163,6 +162,20 @@
     [self.delegate userNotificationCenter:center
        didReceiveNotificationResponse:response
                 withCompletionHandler:completionHandler];
+
+    if (![response.notification.request.trigger isKindOfClass:UNPushNotificationTrigger.class])
+        return;
+    
+    NSDictionary *mutableUserInfo = [response.notification.request.content.userInfo mutableCopy];
+
+    [mutableUserInfo setValue:@YES forKey:@"tap"];
+
+    // Print full message.
+    NSLog(@"Response %@", mutableUserInfo);
+
+    [FirebasePlugin.firebasePlugin sendNotification:mutableUserInfo];
+
+    completionHandler();
 }
 
 // Receive data message on iOS 10 devices.

--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -14,8 +14,21 @@
 #endif
 
 #define kApplicationInBackgroundKey @"applicationInBackground"
+#define kDelegateKey @"delegate"
 
 @implementation AppDelegate (FirebasePlugin)
+
+#if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
+
+- (void)setDelegate:(id)delegate {
+    objc_setAssociatedObject(self, kDelegateKey, delegate, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (id)delegate {
+    return objc_getAssociatedObject(self, kDelegateKey);
+}
+
+#endif
 
 + (void)load {
     Method original = class_getInstanceMethod(self, @selector(application:didFinishLaunchingWithOptions:));
@@ -41,6 +54,10 @@
     // [START set_messaging_delegate]
     [FIRMessaging messaging].delegate = self;
     // [END set_messaging_delegate]
+#if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
+    self.delegate = [UNUserNotificationCenter currentNotificationCenter].delegate;
+    [UNUserNotificationCenter currentNotificationCenter].delegate = self;
+#endif
         
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(tokenRefreshNotification:)
                                                  name:kFIRInstanceIDTokenRefreshNotification object:nil];
@@ -120,6 +137,15 @@
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
        willPresentNotification:(UNNotification *)notification
          withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
+    
+    [self.delegate userNotificationCenter:center
+              willPresentNotification:notification
+                withCompletionHandler:completionHandler];
+
+    UNNotificationRequest* toast = notification.request;
+    if (![toast.trigger isKindOfClass:UNPushNotificationTrigger.class])
+        return;
+    
     NSDictionary *mutableUserInfo = [notification.request.content.userInfo mutableCopy];
 
     [mutableUserInfo setValue:self.applicationInBackground forKey:@"tap"];
@@ -128,6 +154,15 @@
     NSLog(@"%@", mutableUserInfo);
 
     [FirebasePlugin.firebasePlugin sendNotification:mutableUserInfo];
+}
+
+- (void) userNotificationCenter:(UNUserNotificationCenter *)center
+ didReceiveNotificationResponse:(UNNotificationResponse *)response
+          withCompletionHandler:(void (^)(void))completionHandler
+{
+    [self.delegate userNotificationCenter:center
+       didReceiveNotificationResponse:response
+                withCompletionHandler:completionHandler];
 }
 
 // Receive data message on iOS 10 devices.

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -119,7 +119,6 @@ static FirebasePlugin *firebasePlugin;
 
             if (![NSThread isMainThread]) {
                 dispatch_sync(dispatch_get_main_queue(), ^{
-                    [[UNUserNotificationCenter currentNotificationCenter] setDelegate:self];
                     [[FIRMessaging messaging] setDelegate:self];
                     [[UIApplication sharedApplication] registerForRemoteNotifications];
 
@@ -127,7 +126,6 @@ static FirebasePlugin *firebasePlugin;
                     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
                 });
             } else {
-                [[UNUserNotificationCenter currentNotificationCenter] setDelegate:self];
                 [[FIRMessaging messaging] setDelegate:self];
                 [[UIApplication sharedApplication] registerForRemoteNotifications];
                 CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];


### PR DESCRIPTION
Local notifications on iOS via cordova-plugin-local-notification were not working.

UNUserNotificationCenter accepts a single delegate that handles the display of notifications. cordova-plugin-firebase now stores a reference to the existing delegate if any and proxies the delegate-calls (cordova-plugin-local-notification is already doing that in the other direction when applicable).

This is basically just undoing some changes made in #576 