### PR TITLE
Set priority and importance to maximum on android by default

### DIFF
--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -135,6 +135,7 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
                     .setAutoCancel(true)
                     .setSound(defaultSoundUri)
                     .setContentIntent(pendingIntent)
+                    .setPriority(NotificationCompat.PRIORITY_MAX);
             ;
 
             int resID = getResources().getIdentifier("notification_icon", "drawable", getPackageName());
@@ -170,6 +171,7 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
                 int accentID = getResources().getIdentifier("accent", "color", getPackageName());
                 notificationBuilder.setColor(getResources().getColor(accentID, null));
+                
             }
 
             Notification notification = notificationBuilder.build();
@@ -180,7 +182,6 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
                     notification.contentView.setImageViewResource(iconID, notiID);
                 }
             }
-            notification.setPriority(NotificationCompat.PRIORITY_MAX);
             NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 
             // Since android Oreo notification channel is needed.

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -136,7 +136,6 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
                     .setSound(defaultSoundUri)
                     .setContentIntent(pendingIntent)
                     .setPriority(NotificationCompat.PRIORITY_MAX);
-            ;
 
             int resID = getResources().getIdentifier("notification_icon", "drawable", getPackageName());
             if (resID != 0) {

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -180,11 +180,12 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
                     notification.contentView.setImageViewResource(iconID, notiID);
                 }
             }
+            notification.setPriority(NotificationCompat.PRIORITY_MAX);
             NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 
             // Since android Oreo notification channel is needed.
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-                NotificationChannel channel = new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_DEFAULT);
+                NotificationChannel channel = new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH);
                 notificationManager.createNotificationChannel(channel);
             }
 


### PR DESCRIPTION
If importance is not maximum on android, notifications  won't be allowed to popup. This fixes this issue: https://github.com/arnesson/cordova-plugin-firebase/issues/472