### PR TITLE
remove resource file auto include GoogleService-Info.plist

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -85,8 +85,6 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 			<string>production</string>
 		</config-file>
 
-		<resource-file src="src/ios/GoogleService-Info.plist" />
-
 		<header-file src="src/ios/AppDelegate+FirebasePlugin.h" />
 		<source-file src="src/ios/AppDelegate+FirebasePlugin.m" />
 		<header-file src="src/ios/FirebasePlugin.h" />


### PR DESCRIPTION
remove resource file auto include GoogleService-Info.plist this will cause error when u have it already add in config.xml and remove platform ios and re add