### PR TITLE
New function: Clear all notifications

### DIFF
--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -1,5 +1,6 @@
 package org.apache.cordova.firebase;
 
+import android.app.NotificationManager;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -188,6 +189,9 @@ public class FirebasePlugin extends CordovaPlugin {
             return true;
         } else if (action.equals("setAnalyticsCollectionEnabled")) {
             this.setAnalyticsCollectionEnabled(callbackContext, args.getBoolean(0));
+            return true;
+        } else if (action.equals("clearAllNotifications")) {
+            this.clearAllNotifications(callbackContext);
             return true;
         }
 
@@ -869,6 +873,20 @@ public class FirebasePlugin extends CordovaPlugin {
                     FirebaseCrash.log(e.getMessage());
                     e.printStackTrace();
                     callbackContext.error(e.getMessage());
+                }
+            }
+        });
+    }
+
+    public void clearAllNotifications(final CallbackContext callbackContext) {
+        cordova.getThreadPool().execute(new Runnable() {
+            public void run() {
+                try {
+                    Context context = cordova.getActivity();
+                    NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                    nm.cancelAll();
+                    callbackContext.success();
+                } catch (Exception e) {
                 }
             }
         });

--- a/src/ios/FirebasePlugin.h
+++ b/src/ios/FirebasePlugin.h
@@ -31,6 +31,7 @@
 - (void)incrementCounter:(CDVInvokedUrlCommand*)command;
 - (void)stopTrace:(CDVInvokedUrlCommand*)command;
 - (void)setAnalyticsCollectionEnabled:(CDVInvokedUrlCommand*)command;
+- (void)clearAllNotifications:(CDVInvokedUrlCommand *)command;
 @property (nonatomic, copy) NSString *notificationCallbackId;
 @property (nonatomic, copy) NSString *tokenRefreshCallbackId;
 @property (nonatomic, retain) NSMutableArray *notificationStack;

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -449,4 +449,13 @@ static FirebasePlugin *firebasePlugin;
      }];
 }
 
+- (void)clearAllNotifications:(CDVInvokedUrlCommand *)command {
+	[self.commandDelegate runInBackground:^{
+        [[UIApplication sharedApplication] setApplicationIconBadgeNumber:1];
+        [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }];
+}
 @end

--- a/www/firebase-browser.js
+++ b/www/firebase-browser.js
@@ -141,3 +141,9 @@ exports.setAnalyticsCollectionEnabled = function (enabled, success, error) {
         success();
     }
 };
+
+exports.clearAllNotifications = function(success, error) {
+    if (typeof success === 'function') {
+        success();
+    }
+};

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -155,3 +155,7 @@ exports.verifyPhoneNumber = function (number, timeOutDuration, success, error) {
       exec(success, error, "FirebasePlugin", "verifyPhoneNumber", [number, timeOutDuration]);
     }
 };
+
+exports.clearAllNotifications = function(success, error) {
+    exec(success, error, "FirebasePlugin", "clearAllNotifications", []);
+};


### PR DESCRIPTION
window.FirebasePlugin.clearAllNotifications()

This is a resubmission of https://github.com/arnesson/cordova-plugin-firebase/pull/403 from Rignacio that has been rebased over 1.0.5.

Tested on iOS 11 and Android 7/8.