### PR TITLE
Add example for configuring GTM on iOS platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,17 @@ Hooks does not work with PhoneGap Build. This means you will have to manually ma
 Your build may fail if you are installing multiple plugins that use Google Play Services.  This is caused by the plugins installing different versions of the Google Play Services library.  This can be resolved by installing [cordova-android-play-services-gradle-release](https://github.com/dpa99c/cordova-android-play-services-gradle-release).
 
 ## Google Tag Manager
-### Android
 Download your container-config json file from Tag Manager and add a resource-file node in your config.xml.
+### Android
 ```
-....
 <platform name="android">
-    <content src="index.html" />
-    <resource-file src="GTM-5MFXXXX.json" target="assets/containers/GTM-5MFXXXX.json" />
+    <resource-file src="GTM-XXXXXXX.json" target="assets/containers/GTM-XXXXXXX.json" />
+    ...
+```
+### iOS
+```
+<platform name="ios">
+    <resource-file src="GTM-YYYYYYY.json" />
     ...
 ```
 


### PR DESCRIPTION
Because there is a configuration example for setting up the plugin for Google Tag Manager on Android only and no explicit example for iOS, developers might be thinking that iOS is not supported. So I updated the README to fix this.