### PR TITLE
Added option to enable user to disconnect FCM in the background

### DIFF
--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -72,11 +72,13 @@
     self.applicationInBackground = @(NO);
 }
 
+#if defined(__DISCONNECT_IN_BACKGROUND)
 - (void)applicationDidEnterBackground:(UIApplication *)application {
     [[FIRMessaging messaging] disconnect];
     self.applicationInBackground = @(YES);
     NSLog(@"Disconnected from FCM");
 }
+#endif
 
 - (void)tokenRefreshNotification:(NSNotification *)notification {
     // Note that this callback will be fired everytime a new token is generated, including the first


### PR DESCRIPTION
Since Apple disallows showing notification banners while the app is in foreground, and it is not necessary to disconnect FCM in the background, so I added a condition to stub the method by default.

But I'm not sure adding the option using a preprocessor macro is the best way to do this. If there is a better approach, please feel free to adjust it or advise me.