### PR TITLE
Changes to make setScreenName run in main thread.

### DIFF
--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -292,14 +292,12 @@ static FirebasePlugin *firebasePlugin;
 }
 
 - (void)setScreenName:(CDVInvokedUrlCommand *)command {
-    [self.commandDelegate runInBackground:^{
-        NSString* name = [command.arguments objectAtIndex:0];
+    NSString* name = [command.arguments objectAtIndex:0];
 
-        [FIRAnalytics setScreenName:name screenClass:NULL];
+    [FIRAnalytics setScreenName:name screenClass:NULL];
 
-        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-    }];
+    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void)setUserId:(CDVInvokedUrlCommand *)command {


### PR DESCRIPTION
I've made changes to the `setScreenName` function to run in the main thread.  This is needed to make it work for iOS.