### PR TITLE
System.exit is hardly relevant to plugin uninitialization.

### DIFF
--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -217,7 +217,7 @@ public class FirebasePlugin extends CordovaPlugin {
     @Override
     public void onDestroy() {
         super.onDestroy();
-        System.exit(0);
+        // System.exit(0);
 
         if (this.appView != null) {
             appView.handleDestroy();

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -217,7 +217,6 @@ public class FirebasePlugin extends CordovaPlugin {
     @Override
     public void onDestroy() {
         super.onDestroy();
-        // System.exit(0);
 
         if (this.appView != null) {
             appView.handleDestroy();


### PR DESCRIPTION
System.exit is hardly relevant to plugin uninitialization.
Also, conflict with inapp-updater plugin.
The plugin should not call System.exit.