### PR TITLE
Hide iOS push notifications when app is in foreground

### DIFF
--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -165,7 +165,7 @@
     // Print full message.
     NSLog(@"%@", mutableUserInfo);
 
-    completionHandler(UNNotificationPresentationOptionAlert);
+    completionHandler(UNNotificationPresentationOptionNone);
     [FirebasePlugin.firebasePlugin sendNotification:mutableUserInfo];
 }
 


### PR DESCRIPTION
This hides the push notification in iOS if the app is in foreground by using `UNNotificationPresentationOptionNone` instead of `UNNotificationPresentationOptionAlert` in the completion handler.