### PR TITLE
Updating install script to make necessary build changes to enable Cra…

### DIFF
--- a/scripts/lib/ios-helper.js
+++ b/scripts/lib/ios-helper.js
@@ -1,12 +1,11 @@
 var fs = require("fs");
-var path = require("path");
 var utilities = require("./utilities");
 
 /**
  * This is used as the display text for the build phase block in XCode as well as the
  * inline comments inside of the .pbxproj file for the build script phase block.
  */
-var comment = "\"Fabric.io: Crashlytics\"";
+var comment = "\"Crashlytics\"";
 
 module.exports = {
 
@@ -25,12 +24,12 @@ module.exports = {
     xcodeProject.parseSync();
 
     // Build the body of the script to be executed during the build phase.
-    //var script = '"' + '\\"${SRCROOT}\\"' + "/\\\"" + utilities.getAppName(context) + "\\\"/Plugins/cordova-fabric-plugin/Fabric.framework/run " + pluginConfig.apiKey + " " + pluginConfig.apiSecret + '"';
+    var script = '"' + '\\"${SRCROOT}\\"' + "/\\\"" + utilities.getAppName(context) + "\\\"/Plugins/" + utilities.getPluginId() + "/Fabric.framework/run" + '"';
 
     // Generate a unique ID for our new build phase.
     var id = xcodeProject.generateUuid();
     // Create the build phase.
-    /*xcodeProject.hash.project.objects.PBXShellScriptBuildPhase[id] = {
+    xcodeProject.hash.project.objects.PBXShellScriptBuildPhase[id] = {
           isa: "PBXShellScriptBuildPhase",
           buildActionMask: 2147483647,
           files: [],
@@ -41,7 +40,7 @@ module.exports = {
           shellPath: "/bin/sh",
           shellScript: script,
           showEnvVarsInLog: 0
-        };*/
+        };
 
     // Add a comment to the block (viewable in the source of the pbxproj file).
     xcodeProject.hash.project.objects.PBXShellScriptBuildPhase[id + "_comment"] = comment;

--- a/scripts/lib/utilities.js
+++ b/scripts/lib/utilities.js
@@ -37,7 +37,7 @@ module.exports = {
      * The ID of the plugin; this should match the ID in plugin.xml.
      */
   getPluginId: function () {
-    return "cordova-fabric-plugin";
+    return "cordova-plugin-firebase";
   },
 
   /**


### PR DESCRIPTION
…shlytics on iOS

I believe this should be sufficient for enabling Crashlytics on iOS, specifically adding the build phase mentioned in the Fabric guide, https://firebase.google.com/docs/crashlytics/get-started#ios

To test this, remove and install the plugin via `cordova plugin add https://github.com/briantq/cordova-plugin-firebase.git#enable-crashlytics-ios`.  Ensure there is a Crashlytics build task.

Note, without PR #832, you will still need to manually initialize Crashlytics to test Crashlytics properly. 

