### PR TITLE
Adding Google Play Service back as a dependency after remove in PR #784

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -55,6 +55,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		<source-file src="src/android/colors.xml" target-dir="res/values" />
 
 		<framework src="src/android/build.gradle" custom="true" type="gradleReference" />
+		<framework src="com.google.gms:google-services:+" />
 		<framework src="com.google.android.gms:play-services-tagmanager:+" />
 		<framework src="com.google.firebase:firebase-core:+" />
 		<framework src="com.google.firebase:firebase-messaging:+" />


### PR DESCRIPTION
Adding google play services dependency back to Android as it is specified in the documentation

Documentation describing dependency: https://firebase.google.com/docs/android/setup

