### PR TITLE
Android build

### DIFF
--- a/scripts/after_plugin_add.js
+++ b/scripts/after_plugin_add.js
@@ -10,8 +10,8 @@ module.exports = function(context) {
     // Modify the Gradle build file to add a task that will upload the debug symbols
     // at build time.
     if (platforms.indexOf("android") !== -1) {
-        androidHelper.removeFabricBuildToolsFromGradle();
-        androidHelper.addFabricBuildToolsGradle();
+        androidHelper.restoreRootBuildGradle();
+        androidHelper.modifyRootBuildGradle();
     }
 
     // Add a build phase which runs a shell script that executes the Crashlytics

--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -51,33 +51,10 @@ var PLATFORM = {
       'www/google-services.json',
       ANDROID_DIR + '/app/src/main/google-services.json'
     ],
-    stringsXml: fileExists(ANDROID_DIR + '/app/src/main/res/values/strings.xml') ? ANDROID_DIR + '/app/src/main/res/values/strings.xml' : ANDROID_DIR + '/res/values/strings.xml'
   }
 };
 
-function updateStringsXml(contents) {
-    var json = JSON.parse(contents);
-    var strings = fs.readFileSync(PLATFORM.ANDROID.stringsXml).toString();
-
-    // replace the value
-    strings = strings.replace(new RegExp('<string name="google_app_id">([^<]+?)</string>', 'i'), '<string name="google_app_id">' + json.client[0].client_info.mobilesdk_app_id + '</string>');
-
-    // replace the value
-    strings = strings.replace(new RegExp('<string name="google_api_key">([^<]+?)</string>', 'i'), '<string name="google_api_key">' + json.client[0].api_key[0].current_key + '</string>');
-	
-	// strip default value if still present
-    strings = strings.replace(new RegExp('<string name="google_app_id">\@([^<]+?)</string>', 'i'), '');
-
-    // strip default value if still present
-    strings = strings.replace(new RegExp('<string name="google_api_key">\@([^<]+?)</string>', 'i'), '');
-
-    // strip empty lines
-    strings = strings.replace(new RegExp('(\r\n|\n|\r)[ \t]*(\r\n|\n|\r)', 'gm'), '$1');
-
-    fs.writeFileSync(PLATFORM.ANDROID.stringsXml, strings);
-}
-
-function copyKey (platform, callback) {
+function copyKey (platform) {
   for (var i = 0; i < platform.src.length; i++) {
     var file = platform.src[i];
     if (fileExists(file)) {
@@ -93,8 +70,6 @@ function copyKey (platform, callback) {
         } catch (e) {
           // skip
         }
-
-        callback && callback(contents);
       } catch (err) {
         console.log(err);
       }
@@ -139,6 +114,6 @@ module.exports = function (context) {
   }
   if (platforms.indexOf('android') !== -1 && directoryExists(ANDROID_DIR)) {
     console.log('Preparing Firebase on Android');
-    copyKey(PLATFORM.ANDROID, updateStringsXml);
+    copyKey(PLATFORM.ANDROID);
   }
 };

--- a/scripts/before_plugin_rm.js
+++ b/scripts/before_plugin_rm.js
@@ -9,7 +9,7 @@ module.exports = function(context) {
 
     // Remove the Gradle modifications that were added when the plugin was installed.
     if (platforms.indexOf("android") !== -1) {
-        androidHelper.removeFabricBuildToolsFromGradle();
+        androidHelper.restoreRootBuildGradle();
     }
 
     // Remove the build script that was added when the plugin was installed.

--- a/scripts/lib/android-helper.js
+++ b/scripts/lib/android-helper.js
@@ -17,14 +17,15 @@ function readRootBuildGradle() {
 /*
  * Added a dependency on 'com.google.gms' based on the position of the know 'com.android.tools.build' dependency in the build.gradle
  */
-function addGPSDependencies(buildGradle) {
+function addDependencies(buildGradle) {
   // find the known line to match
   var match = buildGradle.match(/^(\s*)classpath 'com.android.tools.build(.*)/m);
   var whitespace = match[1];
   
   // modify the line to add the necessary dependencies
-  var googlePlayDependency = whitespace + 'classpath \'com.google.gms:google-services:4.1.0\' // google-services plugin from cordova-plugin-firebase';
-  var modifiedLine = match[0] + '\n' + googlePlayDependency;
+  var googlePlayDependency = whitespace + 'classpath \'com.google.gms:google-services:4.1.0\' // google-services dependency from cordova-plugin-firebase';
+  var fabricDependency = whitespace + 'classpath \'io.fabric.tools:gradle:1.25.4\' // fabric dependency from cordova-plugin-firebase'
+  var modifiedLine = match[0] + '\n' + googlePlayDependency + '\n' + fabricDependency;
   
   // modify the actual line
   return buildGradle.replace(/^(\s*)classpath 'com.android.tools.build(.*)/m, modifiedLine);
@@ -33,14 +34,15 @@ function addGPSDependencies(buildGradle) {
 /*
  * Add 'google()' to the repository repo list
  */
-function addGoogleRepo(buildGradle) {
+function addRepos(buildGradle) {
   // find the known line to match
   var match = buildGradle.match(/^(\s*)jcenter\(\)/m);
   var whitespace = match[1];
 
   // modify the line to add the necessary repo
   var googlesMavenRepo = whitespace + 'google() // Google\'s Maven repository from cordova-plugin-firebase';
-  var modifiedLine = match[0] + '\n' + googlesMavenRepo;
+  var fabricMavenRepo = whitespace + 'maven { url \'https://maven.fabric.io/public\' } // Fabrics Maven repository from cordova-plugin-firebase'
+  var modifiedLine = match[0] + '\n' + googlesMavenRepo + '\n' + fabricMavenRepo;
 
   // modify the actual line
   return buildGradle.replace(/^(\s*)jcenter\(\)/m, modifiedLine);
@@ -65,10 +67,10 @@ module.exports = {
     var buildGradle = readRootBuildGradle();
 
     // Add Google Play Services Dependency
-    buildGradle = addGPSDependencies(buildGradle);
+    buildGradle = addDependencies(buildGradle);
   
     // Add Google's Maven Repo
-    buildGradle = addGoogleRepo(buildGradle);
+    buildGradle = addRepos(buildGradle);
 
     writeRootBuildGradle(buildGradle);
   },

--- a/scripts/lib/android-helper.js
+++ b/scripts/lib/android-helper.js
@@ -1,6 +1,11 @@
 var fs = require("fs");
 var path = require("path");
 
+function rootBuildGradleExists() {
+  var target = path.join("platforms", "android", "build.gradle");
+  return fs.existsSync(target);
+}
+
 /*
  * Helper function to read the build.gradle that sits at the root of the project
  */
@@ -52,6 +57,11 @@ function writeRootBuildGradle(contents) {
 module.exports = {
 
   modifyRootBuildGradle: function() {
+    // be defensive and don't crash if the file doesn't exist
+    if (!rootBuildGradleExists) {
+      return;
+    }
+
     var buildGradle = readRootBuildGradle();
 
     // Add Google Play Services Dependency
@@ -64,6 +74,11 @@ module.exports = {
   },
 
   restoreRootBuildGradle: function() {
+    // be defensive and don't crash if the file doesn't exist
+    if (!rootBuildGradleExists) {
+      return;
+    }
+
     var buildGradle = readRootBuildGradle();
 
     // remove any lines we added

--- a/scripts/lib/utilities.js
+++ b/scripts/lib/utilities.js
@@ -3,21 +3,6 @@
  */
 
 var path = require("path");
-var fs = require("fs");
-
-/**
- * Used to get the path to the build.gradle file for the Android project.
- *
- * @returns {string} The path to the build.gradle file.
- */
-function getBuildGradlePath () {
-  var target = path.join("platforms", "android", "app", "build.gradle");
-  if (fs.existsSync(target)) {
-    return target;
-  }
-
-  return path.join("platforms", "android", "build.gradle");
-}
 
 module.exports = {
 
@@ -53,22 +38,4 @@ module.exports = {
     return path.join("platforms", "ios", appName + ".xcodeproj", "project.pbxproj");
   },
 
-  /**
-     * Used to read the contents of the Android project's build.gradle file.
-     *
-     * @returns {string} The contents of the Android project's build.gradle file.
-     */
-  readBuildGradle: function () {
-    return fs.readFileSync(getBuildGradlePath(), "utf-8");
-  },
-
-  /**
-     * Used to write the given build.gradle contents to the Android project's
-     * build.gradle file.
-     *
-     * @param {string} buildGradle The body of the build.gradle file to write.
-     */
-  writeBuildGradle: function (buildGradle) {
-    fs.writeFileSync(getBuildGradlePath(), buildGradle);
-  }
 };

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -25,4 +25,5 @@ dependencies {
 
 cdvPluginPostBuildExtras.add({
     apply plugin: 'com.google.gms.google-services'
+    apply plugin: 'io.fabric'
 })


### PR DESCRIPTION
This should resolve all the Android build problems related to the Crashlytics Pull Request #784.  I spent last night and this morning figuring out how the build system work, both Cordova's and the scripts in the project.  

The issue for #837 is that the Crashlytics Pull Request removed some keys that Firebase needed.  As in the comments, it was outside the scope of the PR.  Had those not been removed, it should have built correctly.

Then the fix in PR #816 didn't resolve the initFirebase issue.  It did get closer to the right way to do it though, which is to use the google services plugin instead of modifying keys directly.

So to get the google play services plugin to work Issue #837, we need to modify the build.gradle in the root of the project.  Since that was not possible via the Cordova hooks, I rewrote the add plugin/remove plugin hooks (as they did not work).

After the first commit I was able to get it to compile, but then when I ran I encountered #848.  This was due to a key that the Crashlytics plugin randomly generates for each build.  Instead of trying to add code to generate the key, I instead opted to use the recommended way of calling the io.fabric gradle plugin.  To do this, we again needed to modify the root build.gradle.

Lastly, since I couldn't figure out how it worked in v1.0.5, I found that there was a step in the prepare hook that set some of the keys firebase is looking for that are generated by the google services plugin.  Since we are now using the recommended way to generate the keys, we no longer need to hack the custom keys ourselves so I removed the code.

After all of that, I think things should now be working, so I am going to enjoy the rest of my weekend :)