### PR TITLE
Explicitly calling out platform files should not be modified/checked …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,8 @@ Submitting a bug fix or feature takes only a few minutes.
 4. Create a commit and push it to your repo.
 5. See the Pull Request section to let us know your code is ready to be merged into the main repo.
 
+MAKE SURE THE CODE WORKS WITHOUT MODIFYING OR CHECKING IN ANY PLATFORM FILES.  Any changes to platform files (like build scripts, config files or anything in the /platform directory) should be made by the plugin.  Since Cordova 4.3.0, the [platform management feature](https://cordova.apache.org/docs/en/latest/platform_plugin_versioning_ref/) allows you to build your project without checking in any platform files.  
+
 # Pull Requests
 
 * Fill in [the required template](PULL_REQUEST_TEMPLATE.md)


### PR DESCRIPTION
…in to get features to work as this is an antipattern.

Since the only way one of the PRs could have built successfully was to modify a build.gradle file in their dev environment, I wanted to spell out the fact that submissions should not rely on any files that are checked in/modified in the platform directory.