### PR TITLE
Retrieving verificationId and code from credential object

### DIFF
--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -734,7 +734,7 @@ public class FirebasePlugin extends CordovaPlugin {
                                 returnResults.put("verificationId", verificationId);
                                 returnResults.put("code", code);
                                 returnResults.put("instantVerification", true);
-                            } catch(JSONException | IllegalAccessException | NoSuchFieldException e){
+                            } catch(Exception e){ // JSONException | IllegalAccessException | NoSuchFieldException
                                 Crashlytics.logException(e);
                                 callbackContext.error(e.getMessage());
                                 return;

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -741,9 +741,9 @@ public class FirebasePlugin extends CordovaPlugin {
                                         else if(value.length() >= 4 && value.length() <= 6) code = value;
                                     }
                                 }
-
-                                returnResults.put("verificationId", verificationId != null ? verificationId : false);
-                                returnResults.put("code", code != null ? code : false);
+                                returnResults.put("verified", verificationId != null && code != null);
+                                returnResults.put("verificationId", verificationId);
+                                returnResults.put("code", code);
                                 returnResults.put("instantVerification", true);
                             } catch(JSONException e){
                                 Crashlytics.logException(e);

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -12,7 +12,7 @@ import android.util.Log;
 
 import com.crashlytics.android.Crashlytics;
 import io.fabric.sdk.android.Fabric;
-
+import java.lang.reflect.Field;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -724,13 +724,17 @@ public class FirebasePlugin extends CordovaPlugin {
                             // 2 - Auto-retrieval. On some devices Google Play services can automatically
                             //     detect the incoming verification SMS and perform verificaiton without
                             //     user action.
-                            Log.d(TAG, "success: verifyPhoneNumber.onVerificationCompleted - callback and create a custom JWT Token on server and sign in with custom token - we cant do anything");
+                            Log.d(TAG, "success: verifyPhoneNumber.onVerificationCompleted");
 
                             JSONObject returnResults = new JSONObject();
                             try {
-                                returnResults.put("verificationId", false);
+                                String verificationId = getPrivateField(credential, "zzfc");
+                                String code = getPrivateField(credential, "zzfd");
+
+                                returnResults.put("verificationId", verificationId);
+                                returnResults.put("code", code);
                                 returnResults.put("instantVerification", true);
-                            } catch (JSONException e) {
+                            } catch(JSONException | IllegalAccessException | NoSuchFieldException e){
                                 Crashlytics.logException(e);
                                 callbackContext.error(e.getMessage());
                                 return;
@@ -782,7 +786,7 @@ public class FirebasePlugin extends CordovaPlugin {
                             callbackContext.sendPluginResult(pluginresult);
                         }
                     };
-
+	
                     PhoneAuthProvider.getInstance().verifyPhoneNumber(number, // Phone number to verify
                             timeOutDuration, // Timeout duration
                             TimeUnit.SECONDS, // Unit of timeout
@@ -794,6 +798,12 @@ public class FirebasePlugin extends CordovaPlugin {
                 }
             }
         });
+    }
+	
+    private String getPrivateField(PhoneAuthCredential credential, String field) throws NoSuchFieldException, IllegalAccessException {
+        Field credentialField = credential.getClass().getDeclaredField(field);
+        credentialField.setAccessible(true);
+        return (String) credentialField.get(credential);
     }
 
     //

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -800,7 +800,7 @@ public class FirebasePlugin extends CordovaPlugin {
         });
     }
 	
-    private String getPrivateField(PhoneAuthCredential credential, String field) throws NoSuchFieldException, IllegalAccessException {
+    private static String getPrivateField(PhoneAuthCredential credential, String field) throws NoSuchFieldException, IllegalAccessException {
         Field credentialField = credential.getClass().getDeclaredField(field);
         credentialField.setAccessible(true);
         return (String) credentialField.get(credential);


### PR DESCRIPTION
See discussion @ https://github.com/arnesson/cordova-plugin-firebase/issues/756

This basically retrieves the verificationId and code from the onVerificationCompleted credential. Meaning we can use verificationId and code to finally solve the instant verification issue.

`var code = credential.instantVerification ? credential.code : inputField.value.toString() ;`
If instantVerification is true we get the code directly from firebase without the need to go through an sms process. Otherwise use the sms code entered by the user.

- [ ] API doc needs to be updated accordingly
- [ ] It does work with the single line above and retrieving a valid credential. But I'm not a javascript developer, there might be an even better way to use this to create your own javascript credential object and skip the "firebase.auth.PhoneAuthProvider.credential" part altogether and directly call signInWithCredential. Feedback appreciated