### PR TITLE
Crashlytics - set user identifier api

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -122,6 +122,11 @@ Log an event using Analytics:
 window.FirebasePlugin.logEvent("select_content", {content_type: "page_view", item_id: "home"});
 ```
 
+## setCrashlyticsUserId
+
+Set Crashlytics user identifier.
+- https://firebase.google.com/docs/crashlytics/customize-crash-reports?authuser=0#set_user_ids
+
 ## setScreenName
 
 Set the name of the current screen in Analytics:

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -131,6 +131,9 @@ public class FirebasePlugin extends CordovaPlugin {
         } else if (action.equals("logError")) {
             this.logError(callbackContext, args.getString(0));
             return true;
+        }else if(action.equals("setCrashlyticsUserId")){
+            this.setCrashlyticsUserId(callbackContext, args.getString(0));
+            return true;
         } else if (action.equals("setScreenName")) {
             this.setScreenName(callbackContext, args.getString(0));
             return true;
@@ -490,6 +493,20 @@ public class FirebasePlugin extends CordovaPlugin {
                 } catch (Exception e) {
                     Crashlytics.log(e.getMessage());
                     e.printStackTrace();
+                    callbackContext.error(e.getMessage());
+                }
+            }
+        });
+    }
+
+    private void setCrashlyticsUserId(final CallbackContext callbackContext, final String userId) {
+        cordova.getActivity().runOnUiThread(new Runnable() {
+            public void run() {
+                try {
+                    Crashlytics.setUserIdentifier(userId);
+                    callbackContext.success();
+                } catch (Exception e) {
+                    Crashlytics.logException(e);
                     callbackContext.error(e.getMessage());
                 }
             }

--- a/src/ios/FirebasePlugin.h
+++ b/src/ios/FirebasePlugin.h
@@ -21,6 +21,7 @@
 - (void)sendToken:(NSString*)token;
 - (void)logEvent:(CDVInvokedUrlCommand*)command;
 - (void)logError:(CDVInvokedUrlCommand*)command;
+- (void)setCrashlyticsUserId:(CDVInvokedUrlCommand*)command;
 - (void)setScreenName:(CDVInvokedUrlCommand*)command;
 - (void)setUserId:(CDVInvokedUrlCommand*)command;
 - (void)setUserProperty:(CDVInvokedUrlCommand*)command;

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -293,6 +293,14 @@ static FirebasePlugin *firebasePlugin;
     }];
 }
 
+- (void)setCrashlyticsUserId:(CDVInvokedUrlCommand *)command {
+    NSString* userId = [command.arguments objectAtIndex:0];
+
+    [CrashlyticsKit setUserIdentifier:userId];
+    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 - (void)setScreenName:(CDVInvokedUrlCommand *)command {
     NSString* name = [command.arguments objectAtIndex:0];
 

--- a/www/firebase-browser.js
+++ b/www/firebase-browser.js
@@ -68,6 +68,12 @@ exports.logError = function (message, success, error) {
   }
 };
 
+exports.setCrashlyticsUserId = function (userId, success, error) {
+    if (typeof success === 'function') {
+        success();
+    }
+};
+
 exports.setScreenName = function (name, success, error) {
   if (typeof success === 'function') {
     success();

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -60,6 +60,10 @@ exports.logError = function (message, success, error) {
   exec(success, error, "FirebasePlugin", "logError", [message]);
 };
 
+exports.setCrashlyticsUserId = function (userId, success, error) {
+    exec(success, error, "FirebasePlugin", "setCrashlyticsUserId", [userId]);
+};
+
 exports.setScreenName = function (name, success, error) {
   exec(success, error, "FirebasePlugin", "setScreenName", [name]);
 };


### PR DESCRIPTION
This adds a method to customize crash reports by setting a user identifier, documentation in here:
https://firebase.google.com/docs/crashlytics/customize-crash-reports?authuser=0#set_user_ids
