### PR TITLE
Hide foreground notification with --variable on iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -10,6 +10,8 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		<engine name="cordova" version=">=3.2.0" />
 	</engines>
 
+	<preference name="IOS_HIDE_FOREGROUND_NOTIFICATION" />
+
 	<platform name="android">
 		<hook type="after_plugin_install" src="scripts/android/after_plugin_install.js" />
 		<hook type="before_plugin_uninstall" src="scripts/android/before_plugin_uninstall.js" />
@@ -76,10 +78,13 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 			</feature>
 		</config-file>
 		<config-file parent="aps-environment" target="*/Entitlements-Debug.plist">
-		    <string>development</string>
+			<string>development</string>
 		</config-file>
 		<config-file parent="aps-environment" target="*/Entitlements-Release.plist">
 			<string>production</string>
+		</config-file>
+		<config-file target="*-Info.plist" parent="IosHideForegroundNotification">
+			<string>$IOS_HIDE_FOREGROUND_NOTIFICATION</string>
 		</config-file>
 
 		<resource-file src="src/ios/GoogleService-Info.plist" />

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -190,6 +190,9 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
 
             notificationManager.notify(id.hashCode(), notification);
         } else {
+            if (!FirebasePlugin.inBackground()) {
+                bundle.putBoolean("foreground", true);
+            }
             bundle.putBoolean("tap", false);
             bundle.putString("title", title);
             bundle.putString("body", messageBody);

--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -176,11 +176,17 @@
     NSDictionary *mutableUserInfo = [notification.request.content.userInfo mutableCopy];
 
     [mutableUserInfo setValue:self.applicationInBackground forKey:@"tap"];
-
+    [mutableUserInfo setValue:@YES forKey:@"foreground"];
     // Print full message.
     NSLog(@"%@", mutableUserInfo);
 
-    completionHandler(UNNotificationPresentationOptionAlert);
+    NSString *iosHideForegroundNotification = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"IosHideForegroundNotification"];
+
+    if ([iosHideForegroundNotification isEqual:@"true"]) {
+        completionHandler(UNNotificationPresentationOptionNone);
+    } else {
+        completionHandler(UNNotificationPresentationOptionAlert);
+    }
     [FirebasePlugin.firebasePlugin sendNotification:mutableUserInfo];
 }
 


### PR DESCRIPTION
Was inspired by [#835](https://github.com/arnesson/cordova-plugin-firebase/pull/835)

Install the plugin with `cordova plugin add cordova-plugin-firebase --variable IOS_HIDE_FOREGROUND_NOTIFICATION="true"` to hide notifications on iOS when foreground.

Also added a value `foreground: "true"` in the notification payload for both Android and iOS when the notification is received in foreground to be able to manage this specific case in the Javascript side, especially useful when the notification is hidden.