### PR TITLE
Fix issue with Android not getting Led ON for notifications on Android O

### DIFF
--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -18,6 +18,7 @@ import android.graphics.Color;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
@@ -152,11 +153,12 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
                 Log.d(TAG, "Sound was null ");
             }
 
+            int lightArgb = 0;
             if (lights != null) {
                 try {
                     String[] lightsComponents = lights.replaceAll("\\s", "").split(",");
                     if (lightsComponents.length == 3) {
-                        int lightArgb = Color.parseColor(lightsComponents[0]);
+                        lightArgb = Color.parseColor(lightsComponents[0]);
                         int lightOnMs = Integer.parseInt(lightsComponents[1]);
                         int lightOffMs = Integer.parseInt(lightsComponents[2]);
 
@@ -169,7 +171,6 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
                 int accentID = getResources().getIdentifier("accent", "color", getPackageName());
                 notificationBuilder.setColor(getResources().getColor(accentID, null));
-
             }
 
             Notification notification = notificationBuilder.build();
@@ -184,8 +185,25 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
 
             // Since android Oreo notification channel is needed.
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-                NotificationChannel channel = new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH);
-                notificationManager.createNotificationChannel(channel);
+                List<NotificationChannel> channels = notificationManager.getNotificationChannels();
+
+                boolean channelExists = false;
+                for (int i = 0; i < channels.size(); i++) {
+                    if (channelId.equals(channels.get(i).getId())) {
+                        channelExists = true;
+                    }
+                }
+
+                if (!channelExists) {
+                    NotificationChannel channel = new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH);
+                    channel.enableLights(true);
+                    channel.enableVibration(true);
+                    channel.setShowBadge(true);
+                    if (lights != null) {
+                        channel.setLightColor(lightArgb);
+                    }
+                    notificationManager.createNotificationChannel(channel);
+                }
             }
 
             notificationManager.notify(id.hashCode(), notification);


### PR DESCRIPTION
Fix for issue [#804](https://github.com/arnesson/cordova-plugin-firebase/issues/804)

Create Channel only if it doesn't exist already.
Enable lights (LED), vibration and showBadge on channel creation and set light color if specified in the notification payload.

You might want to change your channel_id in res/values/cordova-firebase-plugin-strings.xml as if i the channel already exists the settings can only be changed by the user on the device.