### PR TITLE
Add logMessage() and sendCrash()

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -369,3 +369,13 @@ window.FirebasePlugin.setAnalyticsCollectionEnabled(true); // Enables analytics 
 
 window.FirebasePlugin.setAnalyticsCollectionEnabled(false); // Disables analytics collection
 ```
+
+## sendCrash
+
+Simulates (causes) a fatal native crash.
+
+```javascript
+window.FirebasePlugin.logMessage("about to send a crash for testing!");
+window.FirebasePlugin.sendCrash();
+```
+

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -201,6 +201,12 @@ public class FirebasePlugin extends CordovaPlugin {
         } else if (action.equals("clearAllNotifications")) {
             this.clearAllNotifications(callbackContext);
             return true;
+        } else if (action.equals("logMessage")) {
+            logMessage(args, callbackContext);
+            return true;
+        } else if (action.equals("sendCrash")) {
+            sendCrash(args, callbackContext);
+            return true;
         }
 
         return false;
@@ -499,6 +505,26 @@ public class FirebasePlugin extends CordovaPlugin {
         });
     }
 
+    private void logMessage(final JSONArray data,
+                        final CallbackContext callbackContext) {
+
+        String message = data.optString(0);
+        Crashlytics.log(message);
+        callbackContext.success();
+    }
+
+    private void sendCrash(final JSONArray data,
+						   final CallbackContext callbackContext) {
+
+		this.cordova.getActivity().runOnUiThread(new Runnable() {
+			@Override
+			public void run() {
+				throw new RuntimeException("This is a crash");
+			}
+		});
+	}
+
+
     private void setCrashlyticsUserId(final CallbackContext callbackContext, final String userId) {
         cordova.getActivity().runOnUiThread(new Runnable() {
             public void run() {
@@ -747,7 +773,7 @@ public class FirebasePlugin extends CordovaPlugin {
                             try {
                                 String verificationId = null;
                                 String code = null;
-								
+
                                 Field[] fields = credential.getClass().getDeclaredFields();
                                 for (Field field : fields) {
                                     Class type = field.getType();
@@ -814,7 +840,7 @@ public class FirebasePlugin extends CordovaPlugin {
                             callbackContext.sendPluginResult(pluginresult);
                         }
                     };
-	
+
                     PhoneAuthProvider.getInstance().verifyPhoneNumber(number, // Phone number to verify
                             timeOutDuration, // Timeout duration
                             TimeUnit.SECONDS, // Unit of timeout
@@ -827,7 +853,7 @@ public class FirebasePlugin extends CordovaPlugin {
             }
         });
     }
-	
+
     private static String getPrivateField(PhoneAuthCredential credential, Field field) {
         try {
             field.setAccessible(true);

--- a/src/ios/FirebasePlugin.h
+++ b/src/ios/FirebasePlugin.h
@@ -34,6 +34,8 @@
 - (void)setAnalyticsCollectionEnabled:(CDVInvokedUrlCommand*)command;
 - (void)setPerformanceCollectionEnabled:(CDVInvokedUrlCommand*)command;
 - (void)clearAllNotifications:(CDVInvokedUrlCommand *)command;
+- (void)logMessage:(CDVInvokedUrlCommand*)command;
+- (void)sendCrash:(CDVInvokedUrlCommand*)command;
 @property (nonatomic, copy) NSString *notificationCallbackId;
 @property (nonatomic, copy) NSString *tokenRefreshCallbackId;
 @property (nonatomic, retain) NSMutableArray *notificationStack;

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -293,6 +293,18 @@ static FirebasePlugin *firebasePlugin;
     }];
 }
 
+- (void)logMessage:(CDVInvokedUrlCommand*)command{
+    NSString* message = [command argumentAtIndex:0 withDefault:@""];
+    if(message)
+    {
+        CLSNSLog(@"%@",message);
+    }
+}
+
+- (void)sendCrash:(CDVInvokedUrlCommand*)command{
+    [[Crashlytics sharedInstance] crash];
+}
+
 - (void)setCrashlyticsUserId:(CDVInvokedUrlCommand *)command {
     NSString* userId = [command.arguments objectAtIndex:0];
 

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -167,3 +167,12 @@ exports.verifyPhoneNumber = function (number, timeOutDuration, success, error) {
 exports.clearAllNotifications = function (success, error) {
   exec(success, error, "FirebasePlugin", "clearAllNotifications", []);
 };
+
+exports.logMessage = function (message, success, error) {
+    exec(success, error, "FirebasePlugin", "logMessage", [message]);
+};
+
+exports.sendCrash = function (success, error) {
+    exec(success, error, "FirebasePlugin", "sendCrash", []);
+};
+


### PR DESCRIPTION
Adds logMessage() which logs a message direct to Crashlytics (as opposed to logError() which logs an exception).

Adds sendCrash() which calls the Crashlytics API method to simulate (cause) a native app crash.

Both are ported across from [cordova-fabric-plugin](https://github.com/sarriaroman/FabricPlugin)