### PR TITLE
fix: correct the resource target location for android

### DIFF
--- a/docs/GOOGLE_TAG_MANAGER.md
+++ b/docs/GOOGLE_TAG_MANAGER.md
@@ -17,13 +17,15 @@ Download your container-config json file from Tag Manager and add a resource-fil
 
 # Debug
 
-## Firebase
+## Android 
+
+### Firebase
 
 `adb shell setprop log.tag.FA VERBOSE`
 `adb shell setprop log.tag.FA-SVC VERBOSE`
 `adb logcat -v time -s FA FA-SVC`
 
-## Firebase and GoogleTagManager
+### Firebase and GoogleTagManager
 
 `adb shell setprop log.tag.FA VERBOSE`
 `adb shell setprop log.tag.FA-SVC VERBOSE`

--- a/docs/GOOGLE_TAG_MANAGER.md
+++ b/docs/GOOGLE_TAG_MANAGER.md
@@ -4,7 +4,7 @@ Download your container-config json file from Tag Manager and add a resource-fil
 ## Android
 ```
 <platform name="android">
-    <resource-file src="GTM-XXXXXXX.json" target="assets/containers/GTM-XXXXXXX.json" />
+    <resource-file src="GTM-XXXXXXX.json" target="app/src/main/assets/containers/GTM-XXXXXXX.json" />
     ...
 ```
 
@@ -14,3 +14,18 @@ Download your container-config json file from Tag Manager and add a resource-fil
     <resource-file src="GTM-YYYYYYY.json" />
     ...
 ```
+
+# Debug
+
+## Firebase
+
+`adb shell setprop log.tag.FA VERBOSE`
+`adb shell setprop log.tag.FA-SVC VERBOSE`
+`adb logcat -v time -s FA FA-SVC`
+
+## Firebase and GoogleTagManager
+
+`adb shell setprop log.tag.FA VERBOSE`
+`adb shell setprop log.tag.FA-SVC VERBOSE`
+`adb shell setprop log.tag.GoogleTagManager VERBOSE`
+`adb logcat -v time -s FA FA-SVC GoogleTagManager`


### PR DESCRIPTION
The current written target location is incorrect, causing to GoogleTagManager to fail initialization as it cannot find the container resource.

Also adding commands in order to debug and see logs of firebase & gtm
