### PR TITLE
Fix handling of data-message once grantPermission is done

### DIFF
--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -107,6 +107,7 @@ static FirebasePlugin *firebasePlugin;
 
 
 #if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
+    [UNUserNotificationCenter currentNotificationCenter].delegate = self;
     UNAuthorizationOptions authOptions = UNAuthorizationOptionAlert|UNAuthorizationOptionSound|UNAuthorizationOptionBadge;
     [[UNUserNotificationCenter currentNotificationCenter]
         requestAuthorizationWithOptions:authOptions
@@ -114,14 +115,12 @@ static FirebasePlugin *firebasePlugin;
 
             if (![NSThread isMainThread]) {
                 dispatch_sync(dispatch_get_main_queue(), ^{
-                    [[FIRMessaging messaging] setDelegate:self];
                     [[UIApplication sharedApplication] registerForRemoteNotifications];
 
                     CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus: granted ? CDVCommandStatus_OK : CDVCommandStatus_ERROR];
                     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
                 });
             } else {
-                [[FIRMessaging messaging] setDelegate:self];
                 [[UIApplication sharedApplication] registerForRemoteNotifications];
                 CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/test/platform-build.sh
+++ b/test/platform-build.sh
@@ -9,4 +9,4 @@ PLATFORM_VERSION=$3
 FOLDER=".build-$PLATFORM"
 cd $FOLDER
 
-../node_modules/.bin/cordova build $PLATFORM
+../node_modules/.bin/cordova build $PLATFORM --stacktrace --info


### PR DESCRIPTION
# Data Messages handling on iOS

This PR fixes the issues faced on handling data-messages in iOS after `grantPermission` is called. Currently only notification messages are properly handled by the delegate.

## Related issues

- https://github.com/arnesson/cordova-plugin-firebase/issues/996
- https://github.com/arnesson/cordova-plugin-firebase/issues/990
- https://github.com/arnesson/cordova-plugin-firebase/issues/970
- https://github.com/arnesson/cordova-plugin-firebase/issues/966
