### PR TITLE
Added API method enableForegroundNotifications()

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -42,6 +42,7 @@ Notification flow:
 
 1. App is in foreground:
     1. User receives the notification data in the JavaScript callback without any notification on the device itself (this is the normal behaviour of push notifications, it is up to you, the developer, to notify the user)
+    2. Alternatively, you may call enableForegroundNotifications() during app startup, and then user will receive notification messages in the device notification bar, even when the app is in the foreground.
 2. App is in background:
     1. User receives the notification message in its device notification bar
     2. User taps the notification and the app opens
@@ -50,6 +51,13 @@ Notification flow:
 Notification icon on Android:
 
 [Changing notification icon](NOTIFICATIONS.md#changing-notification-icon)
+
+## enableForegroundNotifications
+
+Turn on foreground notifications:
+```
+window.FirebasePlugin.enableForegroundNotifications();
+```
 
 ## grantPermission (iOS only)
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -52,7 +52,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		<source-file src="src/android/FirebasePluginMessagingService.java" target-dir="src/org/apache/cordova/firebase" />
 		<source-file src="src/android/FirebasePluginMessageReceiver.java" target-dir="src/org/apache/cordova/firebase" />
 		<source-file src="src/android/FirebasePluginMessageReceiverManager.java" target-dir="src/org/apache/cordova/firebase" />
-		<source-file src="src/android/colors.xml" target-dir="res/values" />
+		<resource-file src="src/android/colors.xml" target="res/values/colors.xml" />
 
 		<framework src="src/android/build.gradle" custom="true" type="gradleReference" />
 		<framework src="com.google.android.gms:play-services-tagmanager:+" />

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -63,6 +63,7 @@ public class FirebasePlugin extends CordovaPlugin {
     protected static final String KEY = "badge";
 
     private static boolean inBackground = true;
+    private static boolean foregroundEnabled = false;
     private static ArrayList<Bundle> notificationStack = null;
     private static CallbackContext notificationCallbackContext;
     private static CallbackContext tokenRefreshCallbackContext;
@@ -121,6 +122,9 @@ public class FirebasePlugin extends CordovaPlugin {
             return true;
         } else if (action.equals("onNotificationOpen")) {
             this.onNotificationOpen(callbackContext);
+            return true;
+        } else if (action.equals("enableForegroundNotifications")) {
+            this.enableForegroundNotifications(callbackContext);
             return true;
         } else if (action.equals("onTokenRefresh")) {
             this.onTokenRefresh(callbackContext);
@@ -241,6 +245,11 @@ public class FirebasePlugin extends CordovaPlugin {
         }
     }
 
+    private void enableForegroundNotifications(final CallbackContext callbackContext) {
+        FirebasePlugin.foregroundEnabled = true;
+        callbackContext.success();
+    }
+
     private void onTokenRefresh(final CallbackContext callbackContext) {
         FirebasePlugin.tokenRefreshCallbackContext = callbackContext;
 
@@ -304,6 +313,10 @@ public class FirebasePlugin extends CordovaPlugin {
 
     public static boolean inBackground() {
         return FirebasePlugin.inBackground;
+    }
+
+    public static boolean foregroundEnabled() {
+        return FirebasePlugin.foregroundEnabled;
     }
 
     public static boolean hasNotificationsCallback() {
@@ -747,7 +760,7 @@ public class FirebasePlugin extends CordovaPlugin {
                             try {
                                 String verificationId = null;
                                 String code = null;
-								
+
                                 Field[] fields = credential.getClass().getDeclaredFields();
                                 for (Field field : fields) {
                                     Class type = field.getType();
@@ -814,7 +827,7 @@ public class FirebasePlugin extends CordovaPlugin {
                             callbackContext.sendPluginResult(pluginresult);
                         }
                     };
-	
+
                     PhoneAuthProvider.getInstance().verifyPhoneNumber(number, // Phone number to verify
                             timeOutDuration, // Timeout duration
                             TimeUnit.SECONDS, // Unit of timeout
@@ -827,7 +840,7 @@ public class FirebasePlugin extends CordovaPlugin {
             }
         });
     }
-	
+
     private static String getPrivateField(PhoneAuthCredential credential, Field field) {
         try {
             field.setAccessible(true);

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -104,9 +104,8 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
         Log.d(TAG, "Notification Message Sound: " + sound);
         Log.d(TAG, "Notification Message Lights: " + lights);
 
-        // TODO: Add option to developer to configure if show notification when app on foreground
         if (!TextUtils.isEmpty(text) || !TextUtils.isEmpty(title) || (data != null && !data.isEmpty())) {
-            boolean showNotification = (FirebasePlugin.inBackground() || !FirebasePlugin.hasNotificationsCallback()) && (!TextUtils.isEmpty(text) || !TextUtils.isEmpty(title));
+            boolean showNotification = (FirebasePlugin.inBackground() || FirebasePlugin.foregroundEnabled() || !FirebasePlugin.hasNotificationsCallback()) && (!TextUtils.isEmpty(text) || !TextUtils.isEmpty(title));
             sendNotification(id, title, text, data, showNotification, sound, lights);
         }
     }

--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -49,17 +49,17 @@
 
     // get GoogleService-Info.plist file path
     NSString *filePath = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType:@"plist"];
-    
+
     // if file is successfully found, use it
     if(filePath){
         NSLog(@"GoogleService-Info.plist found, setup: [FIRApp configureWithOptions]");
         // create firebase configure options passing .plist as content
         FIROptions *options = [[FIROptions alloc] initWithContentsOfFile:filePath];
-        
+
         // configure FIRApp with options
         [FIRApp configureWithOptions:options];
     }
-    
+
     // no .plist found, try default App
     if (![FIRApp defaultApp] && !filePath) {
         NSLog(@"GoogleService-Info.plist NOT FOUND, setup: [FIRApp defaultApp]");
@@ -125,6 +125,8 @@
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo {
     NSDictionary *mutableUserInfo = [userInfo mutableCopy];
 
+    NSLog(@"Foreground didReceiveRemoteNotification ???");
+
     [mutableUserInfo setValue:self.applicationInBackground forKey:@"tap"];
 
     // Print full message.
@@ -135,6 +137,8 @@
 
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo
     fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+
+    NSLog(@"BACKGROUND didReceiveRemoteNotification !!!");
 
     NSDictionary *mutableUserInfo = [userInfo mutableCopy];
 
@@ -180,7 +184,12 @@
     // Print full message.
     NSLog(@"%@", mutableUserInfo);
 
-    completionHandler(UNNotificationPresentationOptionAlert);
+    if (self.applicationInBackground || [FirebasePlugin.firebasePlugin foregroundEnabled]) {
+      completionHandler(UNNotificationPresentationOptionAlert);
+    } else {
+      completionHandler(UNNotificationPresentationOptionNone);
+    }
+
     [FirebasePlugin.firebasePlugin sendNotification:mutableUserInfo];
 }
 

--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -125,8 +125,6 @@
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo {
     NSDictionary *mutableUserInfo = [userInfo mutableCopy];
 
-    NSLog(@"Foreground didReceiveRemoteNotification ???");
-
     [mutableUserInfo setValue:self.applicationInBackground forKey:@"tap"];
 
     // Print full message.
@@ -137,8 +135,6 @@
 
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo
     fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
-
-    NSLog(@"BACKGROUND didReceiveRemoteNotification !!!");
 
     NSDictionary *mutableUserInfo = [userInfo mutableCopy];
 
@@ -184,7 +180,8 @@
     // Print full message.
     NSLog(@"%@", mutableUserInfo);
 
-    if (self.applicationInBackground || [FirebasePlugin.firebasePlugin foregroundEnabled]) {
+    if ([self.applicationInBackground isEqualToNumber: @(YES)]
+        || [[FirebasePlugin.firebasePlugin foregroundEnabled] isEqualToNumber: @(YES)]) {
       completionHandler(UNNotificationPresentationOptionAlert);
     } else {
       completionHandler(UNNotificationPresentationOptionNone);

--- a/src/ios/FirebasePlugin.h
+++ b/src/ios/FirebasePlugin.h
@@ -16,6 +16,7 @@
 - (void)unsubscribe:(CDVInvokedUrlCommand*)command;
 - (void)unregister:(CDVInvokedUrlCommand*)command;
 - (void)onNotificationOpen:(CDVInvokedUrlCommand*)command;
+- (void)enableForegroundNotifications:(CDVInvokedUrlCommand*)command;
 - (void)onTokenRefresh:(CDVInvokedUrlCommand*)command;
 - (void)sendNotification:(NSDictionary*)userInfo;
 - (void)sendToken:(NSString*)token;
@@ -38,5 +39,6 @@
 @property (nonatomic, copy) NSString *tokenRefreshCallbackId;
 @property (nonatomic, retain) NSMutableArray *notificationStack;
 @property (nonatomic, readwrite) NSMutableDictionary* traces;
+@property (nonatomic, strong) NSNumber *foregroundEnabled;
 
 @end

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -19,6 +19,8 @@
 #define NSFoundationVersionNumber_iOS_9_x_Max 1299
 #endif
 
+#define kForegoundEnabledKey @"foregroundEnabled"
+
 @implementation FirebasePlugin
 
 @synthesize notificationCallbackId;
@@ -36,6 +38,14 @@ static FirebasePlugin *firebasePlugin;
 - (void)pluginInitialize {
     NSLog(@"Starting Firebase plugin");
     firebasePlugin = self;
+}
+
+- (void)setForegroundEnabled:(NSNumber *)foregroundEnabled {
+    objc_setAssociatedObject(self, kForegoundEnabledKey, foregroundEnabled, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (NSNumber *)foregroundEnabled {
+    return objc_getAssociatedObject(self, kForegoundEnabledKey);
 }
 
 - (void)getId:(CDVInvokedUrlCommand *)command {
@@ -227,6 +237,13 @@ static FirebasePlugin *firebasePlugin;
         }
         [self.notificationStack removeAllObjects];
     }
+}
+
+- (void)enableForegroundNotifications:(CDVInvokedUrlCommand *)command {
+    self.foregroundEnabled = @(YES);
+
+    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void)onTokenRefresh:(CDVInvokedUrlCommand *)command {

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -4,6 +4,7 @@
 #import "Firebase.h"
 #import <Fabric/Fabric.h>
 #import <Crashlytics/Crashlytics.h>
+#import <objc/runtime.h>
 @import FirebaseInstanceID;
 @import FirebaseMessaging;
 @import FirebaseAnalytics;

--- a/www/firebase-browser.js
+++ b/www/firebase-browser.js
@@ -24,6 +24,12 @@ exports.getId = function (success, error) {
 
 exports.onNotificationOpen = function (success, error) {};
 
+exports.enableForegroundNotifications = function (success, error) {
+  if (typeof success === 'function') {
+    success();
+  }
+};
+
 exports.onTokenRefresh = function (success, error) {};
 
 exports.grantPermission = function (success, error) {

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -20,6 +20,10 @@ exports.onNotificationOpen = function (success, error) {
   exec(success, error, "FirebasePlugin", "onNotificationOpen", []);
 };
 
+exports.enableForegroundNotifications = function (success, error) {
+  exec(success, error, "FirebasePlugin", "enableForegroundNotifications", []);
+}
+
 exports.onTokenRefresh = function (success, error) {
   exec(success, error, "FirebasePlugin", "onTokenRefresh", []);
 };


### PR DESCRIPTION
This change adds a new API method which should be invoked during app startup:
```
window['FirebasePlugin'].enableForegroundNotifications();
```

If not called, foreground notifications are disabled by default.  Standardized the notification behavior across Android and iOS to respect this setting, and only show foreground notifications if the above method has been called.

Also fixed an Android installation issue when project is providing a custom colors.xml (previously the plugin installation failed if this file already exists in the platform folder). 

Tested successfully with
cordova-android: 7.1.4
cordova-ios: 4.5.4