### PR TITLE
fix google-services version

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:+'
-        classpath 'com.google.gms:google-services:4.1.0'
+        classpath 'com.google.gms:google-services:4.2.0'
     }
 }
 repositories {


### PR DESCRIPTION
without this version of google-services there is a traceback with `ionic cordova build android`

```
> Task :app:fabricGenerateResourcesDebug FAILED
ERROR - Crashlytics Developer Tools error.
java.lang.IllegalArgumentException: Crashlytics found an invalid API key: null.
Check the Crashlytics plugin to make sure that the application has been added successfully!

``

see also: https://stackoverflow.com/questions/52614015/invalid-crashlytics-api-key-error-when-upgrading-to-android-gradle-plugin-3-3-0

# TODO